### PR TITLE
[feat] axios validateStatus 설정에 따라 response type 추가 설정

### DIFF
--- a/app/_common/test/checkInstanceOfResponseError.test.ts
+++ b/app/_common/test/checkInstanceOfResponseError.test.ts
@@ -1,0 +1,20 @@
+import { checkInstanceOfResponseError } from "../utils/checkInstanceOfResponseError";
+
+describe("response 객체 타입 확인", () => {
+  test("response가 400번대 에러인 경우", () => {
+    const response = {
+      timestamp: "2024-02-21T13:39:49.373082006",
+      statusCode: 401,
+      code: "E010201",
+      message: "사용자의 인증 정보를 찾을 수 없습니다.",
+    };
+    expect(checkInstanceOfResponseError(response)).toStrictEqual(true);
+  });
+
+  test("response가 200번대인 경우", () => {
+    const response = {
+      data: [],
+    };
+    expect(checkInstanceOfResponseError(response)).toStrictEqual(false);
+  });
+});

--- a/app/_common/types/response.types.ts
+++ b/app/_common/types/response.types.ts
@@ -1,0 +1,6 @@
+export interface ResponseError {
+  timestamp: string;
+  statusCode: number;
+  code: string;
+  message: string;
+}

--- a/app/_common/utils/checkInstanceOfResponseError.ts
+++ b/app/_common/utils/checkInstanceOfResponseError.ts
@@ -1,0 +1,13 @@
+import { ResponseError } from "../types/response.types";
+
+export const checkInstanceOfResponseError = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  object: any,
+): object is ResponseError => {
+  return (
+    "timestamp" in object &&
+    "statusCode" in object &&
+    "code" in object &&
+    "message" in object
+  );
+};


### PR DESCRIPTION
# 📌 작업 내용

## 문제 상황

```tsx
export const instance = axios.create({
  baseURL: `${BASE_URL}${SERVER_VERSION}`,
  headers: {
    "Content-Type": "application/json",
    Accept: "application/json",
    Authorization: `Bearer ${accessToken}`,
  },
  validateStatus: status => status < 500, // 추가
});
```

현재 범님이 작업해주신 axios instance를 기준으로 `validateStatus: status => status < 500` 코드를 추가했습니다. 

response status가 500 미만인 경우에는 400대 에러여도 axios error를 일으키지 않고 데이터로 넘겨주도록 하는(`promise가 resolve됨`) 설정인데 이렇게 하는 경우에 **리액트 쿼리를 쓰게 된다면 400대 에러가 떴을 때 error 객체로 넘어오지 않고 data 객체로 넘어오는 것을 확인**했습니다!

<img width="692" alt="스크린샷 2024-02-21 오후 12 20 24" src="https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/73841260/491864ef-ae24-4a4f-8fad-0decfedc7851">

따라서

- 받은 타입이 에러 객체일 때 에러 객체 타입 생성
- 받은 데이터 타입이 ResponseError인지 확인하는 유틸 함수 생성

작업을 통해 아래와 같은 데이터 처리를 하도록 작업을 해보았습니다.

```tsx
const { data, isLoading } = useQueryGeoAreaCode();

if (data) {
  if (checkInstanceOfResponseError(data)) {
    toast.error(data.message);
} else setRegionCode(data.areaCode);
```

노션에 적어놓은 내용을 옮겨왔습니다. [노션 문서 링크](https://prgrms.notion.site/axios-validateStatus-response-type-99ae7600e1d74705a1c9128c17a00925?pvs=4)도 첨부합니다.

# 🚦 특이 사항
- 테스트 함수가 잘 작성되었는지 궁금합니다. (목업 response가 잘 들어간 것인지,,)
- 개발 컨벤션에 맞게 짜였는지 궁금합니다.
- 더 좋은 로직이 있는지 궁금합니다. 편하게 리뷰 주세요! :D
