### PR TITLE
[fix] 지도 확대 시 스크롤 생기는 버그 및 손가락 확대 막기

### DIFF
--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -35,7 +35,6 @@ function Map() {
     if (isZoomIn) {
       if (isRegion || !(previousRegion.current instanceof SVGElement)) return;
 
-      map.classList.remove("touch-none");
       map.style.transform = "";
       previousRegion.current.classList.remove("animate-map-bounce");
       previousRegion.current = null;
@@ -57,11 +56,11 @@ function Map() {
   };
 
   return (
-    <div className="relative h-screen w-screen">
+    <div className="relative h-screen w-screen overflow-hidden touch-none">
       <div
         id="map-wrap"
         onClick={handleRegionClick}
-        className="absolute z-0 flex h-screen w-screen items-center justify-center transition-all duration-1000"
+        className="absolute z-0 flex h-screen w-screen items-center justify-center transition-all duration-1000 touch-none"
       >
         <MapComponent
           regionCode={regionCode}
@@ -77,7 +76,7 @@ function Map() {
       >
         <div
           id="carousel-wrap"
-          className="flex h-full w-full flex-col items-center justify-center overflow-hidden"
+          className="flex h-full w-full flex-col items-center justify-center"
         >
           <CarouselContent>
             {Array.from({ length: 5 }).map((_, index) => (

--- a/app/(map)/_components/RankInfo.tsx
+++ b/app/(map)/_components/RankInfo.tsx
@@ -1,6 +1,6 @@
 function RankInfo() {
   return (
-    <aside className="absolute bottom-0 left-0 text-[0.65rem] text-primary">
+    <aside className="absolute bottom-0 left-4 text-[0.65rem] text-primary">
       <div>프로젝트 밀집도 순위</div>
       <ul>
         <li className="flex items-center">

--- a/app/_common/components/MapComponent.tsx
+++ b/app/_common/components/MapComponent.tsx
@@ -42,7 +42,6 @@ function MapComponent({ regionCode, regionRank }: Props) {
 
     const { bottom, top, right, left } = region.getBoundingClientRect();
     const { offsetWidth: width, offsetHeight: height } = document.body;
-    map.classList.add("touch-none");
     map.style.transform = `scale(2.5) translate(${width / 2 - (right + left) / 2}px, ${height / 2 - (bottom + top) / 2}px)`;
     region.classList.add("animate-map-bounce");
   };


### PR DESCRIPTION
# 📌 작업 내용
- 지도 확대 시 스크롤 생기는 버그는 scale로 확대 되었을 때 생기는 스크롤이어서 루트 태그에서 overflow: hidden 속성을 주어 해결했습니다.
- touch-action: none을 통해 지도를 손가락이나 더블탭으로 확대/축소를 막았습니다.

# 🚦 특이 사항
- 놓친 부분이 있거나 잘못된 스타일 값을 주었다면 말씀 주시면 감사하겠습니다!

close #55