### PR TITLE
[style] 업적 페이지 스타일 수정

### DIFF
--- a/app/achievements/_components/AchievementDrawer.tsx
+++ b/app/achievements/_components/AchievementDrawer.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import { IconQuestionMark } from "@tabler/icons-react";
 
+import { cn } from "@/app/_common/shadcn/utils";
 import {
   DrawerContent,
   Drawer,
@@ -36,18 +37,28 @@ function AchievementDrawer({
     <Drawer open={open} onOpenChange={onOpenChange}>
       <DrawerContent id={`${id}`}>
         <DrawerHeader className="place-content-center place-items-center gap-6">
-          <div className="w-[100px]">
-            <AspectRatio ratio={1 / 1} className="relative flex">
-              {!isCompleted && (
-                <IconQuestionMark className="absolute z-10 h-full w-full rounded-xl bg-secondary text-white" />
+          <div className="w-[100px] rounded-xl bg-secondary">
+            <AspectRatio
+              ratio={1 / 1}
+              className={cn(
+                !isCompleted ? "grid place-items-center" : "flex",
+                "relative",
               )}
-              <Image
-                width={100}
-                height={100}
-                src="/images/cat.webp"
-                alt="업적 뱃지"
-                className="rounded-xl object-cover"
-              />
+            >
+              {!isCompleted ? (
+                <IconQuestionMark
+                  size={70}
+                  className="absolute z-10 text-white"
+                />
+              ) : (
+                <Image
+                  width={100}
+                  height={100}
+                  src="/images/cat.webp"
+                  alt="업적 뱃지"
+                  className="rounded-xl object-cover"
+                />
+              )}
             </AspectRatio>
           </div>
           <DrawerTitle>{title}</DrawerTitle>

--- a/app/achievements/_components/AchievementDrawer.tsx
+++ b/app/achievements/_components/AchievementDrawer.tsx
@@ -1,0 +1,73 @@
+import Image from "next/image";
+import { IconQuestionMark } from "@tabler/icons-react";
+
+import {
+  DrawerContent,
+  Drawer,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+  DrawerFooter,
+} from "@/app/_common/shadcn/ui/drawer";
+import { Button } from "@/app/_common/shadcn/ui/button";
+import { AspectRatio } from "@/app/_common/shadcn/ui/aspect-ratio";
+
+import { calculateAchievement } from "../_utils/calculateAchievement";
+import { AchievementProgress } from "./AchievementProgress";
+import { Achievement } from "./AchievementList";
+
+interface AchievementDrawerProps {
+  achievement: Achievement;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}
+function AchievementDrawer({
+  achievement,
+  open,
+  onOpenChange,
+}: AchievementDrawerProps) {
+  const { id, title, isCompleted, description, nowGrade, total } = achievement;
+
+  const handleCloseDrawer = () => {
+    onOpenChange(false);
+  };
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent id={`${id}`}>
+        <DrawerHeader className="place-content-center place-items-center gap-6">
+          <div className="w-[100px]">
+            <AspectRatio ratio={1 / 1} className="relative flex">
+              {!isCompleted && (
+                <IconQuestionMark className="absolute z-10 h-full w-full rounded-xl bg-secondary text-white" />
+              )}
+              <Image
+                width={100}
+                height={100}
+                src="/images/cat.webp"
+                alt="업적 뱃지"
+                className="rounded-xl object-cover"
+              />
+            </AspectRatio>
+          </div>
+          <DrawerTitle>{title}</DrawerTitle>
+          <DrawerDescription>획득방법: {description}</DrawerDescription>
+        </DrawerHeader>
+        <DrawerFooter className="place-items-center">
+          {isCompleted ? (
+            <Button className="w-full" onClick={handleCloseDrawer}>
+              내 대표 업적으로 설정하기
+            </Button>
+          ) : (
+            <AchievementProgress
+              className="w-[300px] bg-secondary bg-opacity-30 dark:bg-opacity-50"
+              value={calculateAchievement(nowGrade, total)}
+            />
+          )}
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+export default AchievementDrawer;

--- a/app/achievements/_components/AchievementItem.tsx
+++ b/app/achievements/_components/AchievementItem.tsx
@@ -1,42 +1,68 @@
-import { cn } from "@/app/_common/shadcn/utils";
+"use client";
 
-import { calculateAchievement } from "../_utils/calculateAchievement";
-import { AchievementProgress } from "./AchievementProgress";
+import { ComponentProps, useState } from "react";
+import Image from "next/image";
+import { IconQuestionMark } from "@tabler/icons-react";
+
+import { cn } from "@/app/_common/shadcn/utils";
+import { AspectRatio } from "@/app/_common/shadcn/ui/aspect-ratio";
+
 import { Achievement } from "./AchievementList";
+import AchievementDrawer from "./AchievementDrawer";
 
 interface AchievementItemProps {
   achievement: Achievement;
+  className?: ComponentProps<typeof cn>;
 }
 
-function AchievementItem({
-  achievement: { title, description, total, nowGrade, isCompleted },
-}: AchievementItemProps) {
+function AchievementItem({ achievement, className }: AchievementItemProps) {
+  const { id, title, isCompleted } = achievement;
+  const [open, setOpen] = useState(false);
+
+  const onOpenChange = () => {
+    setOpen(true);
+  };
+
   return (
-    <li
-      className={cn(
-        isCompleted ? "bg-slate-200" : "bg-white",
-        "flex flex-col rounded-md border px-4 py-3 shadow-md",
-      )}
-    >
-      <header className="mb-2 font-semibold">
-        <h3 className={cn(isCompleted ? "text-gray-400" : "text-primary")}>
+    <>
+      <AchievementDrawer
+        achievement={achievement}
+        open={open}
+        onOpenChange={setOpen}
+      />
+      <li
+        id={`${id}`}
+        className={cn(
+          "flex cursor-pointer flex-col items-center gap-2 rounded-md",
+          className,
+        )}
+        onClick={onOpenChange}
+      >
+        <div className="w-[80px]">
+          <AspectRatio ratio={1 / 1} className="relative flex">
+            {!isCompleted && (
+              // <div className="absolute z-10 h-full w-full rounded-xl backdrop-blur-sm"></div>
+              <IconQuestionMark className="absolute z-10 h-full w-full rounded-xl bg-secondary text-white" />
+            )}
+            <Image
+              width={80}
+              height={80}
+              src="/images/cat.webp"
+              alt="업적 뱃지"
+              className="rounded-xl object-cover"
+            />
+          </AspectRatio>
+        </div>
+        <p
+          className={cn(
+            isCompleted ? "text-primary" : "text-gray-400",
+            "text-balance text-center text-sm",
+          )}
+        >
           {title}
-        </h3>
-        <small className={cn(isCompleted ? "text-gray-400" : "text-gray-500")}>
-          {description}
-        </small>
-      </header>
-      <section className="text-right">
-        <AchievementProgress
-          value={calculateAchievement(nowGrade, total)}
-          className="bg-secondary bg-opacity-30 dark:bg-slate-50 dark:bg-opacity-50"
-          defaultChecked={isCompleted}
-        />
-        <small className="pr-1 text-gray-500">
-          {nowGrade}/{total}
-        </small>
-      </section>
-    </li>
+        </p>
+      </li>
+    </>
   );
 }
 

--- a/app/achievements/_components/AchievementItem.tsx
+++ b/app/achievements/_components/AchievementItem.tsx
@@ -13,9 +13,14 @@ import AchievementDrawer from "./AchievementDrawer";
 interface AchievementItemProps {
   achievement: Achievement;
   className?: ComponentProps<typeof cn>;
+  isRepresentative?: boolean;
 }
 
-function AchievementItem({ achievement, className }: AchievementItemProps) {
+function AchievementItem({
+  achievement,
+  className,
+  isRepresentative,
+}: AchievementItemProps) {
   const { id, title, isCompleted } = achievement;
   const [open, setOpen] = useState(false);
 
@@ -38,29 +43,45 @@ function AchievementItem({ achievement, className }: AchievementItemProps) {
         )}
         onClick={onOpenChange}
       >
-        <div className="w-[80px]">
-          <AspectRatio ratio={1 / 1} className="relative flex">
-            {!isCompleted && (
-              // <div className="absolute z-10 h-full w-full rounded-xl backdrop-blur-sm"></div>
-              <IconQuestionMark className="absolute z-10 h-full w-full rounded-xl bg-secondary text-white" />
-            )}
-            <Image
-              width={80}
-              height={80}
-              src="/images/cat.webp"
-              alt="업적 뱃지"
-              className="rounded-xl object-cover"
-            />
-          </AspectRatio>
-        </div>
-        <p
+        <div
           className={cn(
-            isCompleted ? "text-primary" : "text-gray-400",
-            "text-balance text-center text-sm",
+            !isRepresentative ? "w-[80px]" : "w-[100px]",
+            "rounded-xl bg-secondary",
           )}
         >
-          {title}
-        </p>
+          <AspectRatio
+            ratio={1 / 1}
+            className={cn(
+              !isCompleted ? "grid place-items-center" : "flex ",
+              "relative",
+            )}
+          >
+            {!isCompleted ? (
+              <IconQuestionMark
+                size={50}
+                className="absolute z-10  text-white"
+              />
+            ) : (
+              <Image
+                width={!isRepresentative ? 80 : 100}
+                height={!isRepresentative ? 80 : 100}
+                src="/images/cat.webp"
+                alt="업적 뱃지"
+                className="rounded-xl object-cover"
+              />
+            )}
+          </AspectRatio>
+        </div>
+        {!isRepresentative && (
+          <p
+            className={cn(
+              isCompleted ? "text-primary" : "text-gray-400",
+              "text-balance text-center text-sm",
+            )}
+          >
+            {title}
+          </p>
+        )}
       </li>
     </>
   );

--- a/app/achievements/_components/AchievementList.tsx
+++ b/app/achievements/_components/AchievementList.tsx
@@ -1,3 +1,9 @@
+"use client";
+
+import { toast } from "sonner";
+import { IconLock } from "@tabler/icons-react";
+import { AspectRatio } from "@radix-ui/react-aspect-ratio";
+
 import AchievementItem from "./AchievementItem";
 
 export interface Achievement {
@@ -37,11 +43,39 @@ const ACHIEVEMENTS: Achievement[] = [
 ];
 
 function AchievementList() {
+  const myAchievement = undefined;
+
+  const hanldeClickMyAchievement = () => {
+    toast.message("아직 설정된 업적이 없어요.");
+  };
+
   return (
     <main className="flex flex-col items-center">
       <header className="grid w-full place-content-center place-items-center gap-3 rounded-none border-y border-gray-300 py-8">
-        <h3 className="font-semibold">내 대표 업적</h3>
-        <AchievementItem achievement={ACHIEVEMENTS[2]} />
+        <h3 className="font-semibold">나의 대표 뱃지</h3>
+        <small className="text-center text-xs text-gray-500">
+          <p>아직 획득한 업적이 없어요.</p>
+          <p>획득한 업적으로 &apos;대표 뱃지&apos;을 변경할 수 있어요.</p>
+        </small>
+        {myAchievement ? (
+          <AchievementItem achievement={ACHIEVEMENTS[2]} isRepresentative />
+        ) : (
+          <div
+            className="w-[100px] rounded-xl bg-secondary text-white"
+            onClick={hanldeClickMyAchievement}
+          >
+            <AspectRatio
+              ratio={1 / 1}
+              className="relative grid place-content-center place-items-center"
+            >
+              <IconLock
+                strokeWidth={1.5}
+                size={50}
+                className="absolute z-10 "
+              />
+            </AspectRatio>
+          </div>
+        )}
       </header>
       <ul className="mt-8 grid grid-cols-3 grid-rows-3 gap-4">
         {ACHIEVEMENTS.sort((a, b) => {

--- a/app/achievements/_components/AchievementList.tsx
+++ b/app/achievements/_components/AchievementList.tsx
@@ -1,6 +1,7 @@
 import AchievementItem from "./AchievementItem";
 
 export interface Achievement {
+  id: number;
   title: string;
   description: string;
   total: number;
@@ -10,6 +11,7 @@ export interface Achievement {
 
 const ACHIEVEMENTS: Achievement[] = [
   {
+    id: 1,
     title: "모각코도 한걸음부터",
     description: "접속 30일 이상 시 획득",
     total: 1,
@@ -17,6 +19,7 @@ const ACHIEVEMENTS: Achievement[] = [
     isCompleted: true,
   },
   {
+    id: 2,
     title: "너는 내 운명",
     description: "동일한 상대와 3회 이상 매칭될 시 획득",
     total: 3,
@@ -24,6 +27,7 @@ const ACHIEVEMENTS: Achievement[] = [
     isCompleted: false,
   },
   {
+    id: 3,
     title: "포획 실패는 존재합니다",
     description: "첫 포획 실패 시 획득",
     total: 1,
@@ -34,16 +38,22 @@ const ACHIEVEMENTS: Achievement[] = [
 
 function AchievementList() {
   return (
-    <ul className="mt-2 flex flex-col gap-4 p-4">
-      {ACHIEVEMENTS.sort((a, b) => {
-        if (a.isCompleted === b.isCompleted) {
-          return 0;
-        }
-        return a.isCompleted ? 1 : -1;
-      }).map((achievement, index) => (
-        <AchievementItem achievement={achievement} key={index} />
-      ))}
-    </ul>
+    <main className="flex flex-col items-center">
+      <header className="grid w-full place-content-center place-items-center gap-3 rounded-none border-y border-gray-300 py-8">
+        <h3 className="font-semibold">내 대표 업적</h3>
+        <AchievementItem achievement={ACHIEVEMENTS[2]} />
+      </header>
+      <ul className="mt-8 grid grid-cols-3 grid-rows-3 gap-4">
+        {ACHIEVEMENTS.sort((a, b) => {
+          if (a.isCompleted === b.isCompleted) {
+            return 0;
+          }
+          return a.isCompleted ? 1 : -1;
+        }).map((achievement, index) => (
+          <AchievementItem achievement={achievement} key={index} />
+        ))}
+      </ul>
+    </main>
   );
 }
 

--- a/app/achievements/_components/AchievementList.tsx
+++ b/app/achievements/_components/AchievementList.tsx
@@ -54,7 +54,7 @@ function AchievementList() {
       <header className="grid w-full place-content-center place-items-center gap-3 rounded-none border-y border-gray-300 py-8">
         <h3 className="font-semibold">나의 대표 뱃지</h3>
         <small className="text-center text-xs text-gray-500">
-          <p>아직 획득한 업적이 없어요.</p>
+          {!ACHIEVEMENTS && <p>아직 획득한 업적이 없어요.</p>}
           <p>획득한 업적으로 &apos;대표 뱃지&apos;을 변경할 수 있어요.</p>
         </small>
         {myAchievement ? (

--- a/app/achievements/_components/AchievementProgress.tsx
+++ b/app/achievements/_components/AchievementProgress.tsx
@@ -20,7 +20,6 @@ const AchievementProgress = React.forwardRef<
     <ProgressPrimitive.Indicator
       className={cn(
         "h-full w-full flex-1 bg-secondary transition-all dark:bg-slate-50",
-        props.defaultChecked && "bg-primary",
       )}
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />

--- a/app/achievements/page.tsx
+++ b/app/achievements/page.tsx
@@ -3,7 +3,7 @@ import AchievementList from "./_components/AchievementList";
 function AchievementsPage() {
   return (
     <main className="p-4">
-      <h2 className="py-3 text-center text-2xl font-semibold">내 업적</h2>
+      <h2 className="py-3 text-center text-xl font-semibold">활동 업적</h2>
       <AchievementList />
     </main>
   );


### PR DESCRIPTION
# 📌 작업 내용
- [x] 대표 뱃지가 설정 가능한 스타일로 변경하였습니다.
- [x] 획득한 뱃지가 있는 경우와 없는 경우로 나누어 스타일을 수정하였습니다.
- [x] 업적의 상세 내용을 볼 수 있는 업적 전용 drawer를 추가하고, 기존 progress로 보여주던 스타일을 제거했습니다.

# 🚦 특이 사항
- 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점을 작성해주세요.
기본 업적 페이지 스타일
<img src="https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/114740795/f4e6283c-e111-4c4f-aa50-da698853a3cd" width="200"/>

<img src="https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/114740795/e98b0418-2479-4bc4-ac59-29f7d515de30" width="200"/>

<img src="https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/114740795/58b475ca-5443-4646-81dd-1b0833b7c4b1" width="200"/>
<img src="https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/114740795/5f80d237-cefc-4753-92b5-2a968b0ce7d7" width="200"/>

https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/114740795/35381ac5-f393-4621-ac93-776a5ce51e0e


close #76 