### PR TITLE
[fix] 프로젝트 생성 폼 한글 입력 2번 되는 문제 수정

### DIFF
--- a/app/project/_hooks/useTagSelect.ts
+++ b/app/project/_hooks/useTagSelect.ts
@@ -18,6 +18,9 @@ function useTagSelect(form: IFormProps["form"]) {
       const tag = ref.current?.value || "";
 
       if (key === "Enter") {
+        if (e.nativeEvent.isComposing) {
+          return;
+        }
         if (!isValid(tag)) return;
         setTagList(prev => [...prev, tag]);
         const formattedTagList = tagList.map(t => ({ content: t }));
@@ -30,7 +33,7 @@ function useTagSelect(form: IFormProps["form"]) {
 
   const handleRemoveTag = (tag: string) => {
     setTagList(prev => prev.filter(t => t !== tag));
-    
+
     const currentTagList = form.getValues("tags");
     form.setValue(
       "tags",


### PR DESCRIPTION
# 📌 작업 내용
- [x] ProjectCreateForm에서 분위기 태그 입력을 받을 때, 한글 입력 시 2번 입력되는 문제 수정
  - isComposing 옵션으로 이벤트 발생 여부를 제어하여 중복 입력을 제거했습니다.

# 🚦 특이 사항
- 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점을 작성해주세요.

close #80 