### PR TITLE
[style] 네비게이션 바 구현

### DIFF
--- a/app/_common/components/NavigationBar.tsx
+++ b/app/_common/components/NavigationBar.tsx
@@ -32,7 +32,7 @@ interface NavigationProfileProps {
 
 function NavigationItem(props: NavigationItemProps) {
   const { title, href } = props;
-  
+
   return (
     <div className="mb-2 space-y-2 px-2">
       <Link href={href}>
@@ -108,9 +108,10 @@ function NavigationProfile(props: NavigationProfileProps) {
 // TODO: 튜토리얼과 모각코 페이지를 만들어서 링크를 연결해주세요. 현재는 임시로 '#'로 연결
 function NavigationBar() {
   const { getUser } = useAuthStore();
+
   return (
     <Sheet>
-      <SheetTrigger className="rounded-md p-2 hover:bg-slate-100">
+      <SheetTrigger className="rounded-md p-2 hover:bg-slate-100 h-fit">
         <IconMenu2 />
       </SheetTrigger>
       <SheetContent

--- a/app/_common/components/NavigationBar.tsx
+++ b/app/_common/components/NavigationBar.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import {
+  IconBrandGithub,
+  IconChevronRight,
+  IconMenu2,
+} from "@tabler/icons-react";
+
+import { SignUpUser } from "@/app/signup/_type/signup";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTrigger,
+} from "@/app/_common/shadcn/ui/sheet";
+
+import { useAuthStore } from "../store/useAuthStore";
+import { Separator } from "../shadcn/ui/separator";
+import { Badge } from "../shadcn/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "../shadcn/ui/avatar";
+
+interface NavigationItemProps {
+  title: string;
+  href: string;
+}
+
+interface NavigationProfileProps {
+  user: Partial<SignUpUser>;
+}
+
+function NavigationItem(props: NavigationItemProps) {
+  const { title, href } = props;
+  
+  return (
+    <div className="mb-2 space-y-2 px-2">
+      <Link href={href}>
+        <div className="flex items-center justify-between rounded-md p-3 hover:bg-slate-100">
+          <p className="text-lg">{title}</p>
+          <IconChevronRight />
+        </div>
+      </Link>
+      <Separator />
+    </div>
+  );
+}
+
+function NavigationProfile(props: NavigationProfileProps) {
+  const {
+    user: {
+      username,
+      achievementTitle,
+      githubUrl,
+      avatarUrl,
+      wantedJobs,
+      developLanguages,
+      bio,
+    },
+  } = props;
+
+  return (
+    <section className="flex flex-col gap-5 px-6 py-10 text-lg">
+      <main className="flex justify-evenly gap-5">
+        <aside className="flex items-center justify-center">
+          <Avatar className="h-32 w-32 border-4 border-slate-600">
+            <AvatarImage src={avatarUrl as string} alt="프로필 이미지" />
+            <AvatarFallback>{username}</AvatarFallback>
+          </Avatar>
+        </aside>
+        <aside className="flex flex-col justify-around  gap-1">
+          <div className="space-y-1">
+            <h1 className="flex items-center gap-1">
+              <p className="text-3xl font-semibold">{username}</p>
+              <Link href={githubUrl as string}>
+                <IconBrandGithub
+                  size={32}
+                  color="gray"
+                  className="mt-1 rounded-full p-2 hover:bg-slate-100"
+                />
+              </Link>
+            </h1>
+            <p className="text-left text-sm text-[#F76A6A]">
+              {achievementTitle}
+            </p>
+          </div>
+          <h2 className="max-h-20 min-h-fit overflow-hidden text-ellipsis border-l-4 pl-3 text-left">
+            {bio}
+          </h2>
+        </aside>
+      </main>
+      <footer className="space-y-2">
+        <div className="flex gap-1">
+          {wantedJobs && wantedJobs.map(job => <Badge key={job}>{job}</Badge>)}
+        </div>
+        <div className="flex gap-1">
+          {developLanguages &&
+            developLanguages.length > 0 &&
+            developLanguages.map(lang => (
+              <Badge key={lang.language}>{lang.language}</Badge>
+            ))}
+        </div>
+      </footer>
+    </section>
+  );
+}
+
+// TODO: 튜토리얼과 모각코 페이지를 만들어서 링크를 연결해주세요. 현재는 임시로 '#'로 연결
+function NavigationBar() {
+  const { getUser } = useAuthStore();
+  return (
+    <Sheet>
+      <SheetTrigger className="rounded-md p-2 hover:bg-slate-100">
+        <IconMenu2 />
+      </SheetTrigger>
+      <SheetContent
+        side="right"
+        className="w-[360px] overflow-hidden p-0 sm:w-[540px] sm:rounded-l-3xl"
+      >
+        <SheetHeader>
+          <NavigationProfile user={getUser()} />
+        </SheetHeader>
+        <Separator className="mb-4 h-2 bg-slate-100 shadow-inner" />
+        <NavigationItem title="튜토리얼" href="#" />
+        <NavigationItem title="마이페이지" href="/my-page" />
+        <NavigationItem title="지도" href="/" />
+        <NavigationItem title="채팅" href="/chat" />
+        <NavigationItem title="모각코" href="#" />
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export default NavigationBar;

--- a/app/_common/components/NavigationBar.tsx
+++ b/app/_common/components/NavigationBar.tsx
@@ -38,6 +38,7 @@ function NavigationBar() {
         <NavigationItem title="채팅" href="/chat" />
         <NavigationItem title="모각코" href="#" />
         <NavigationItem title="업적" href="/achievements" />
+        <NavigationItem title="알림" href="/notification" />
       </SheetContent>
     </Sheet>
   );

--- a/app/_common/components/NavigationBar.tsx
+++ b/app/_common/components/NavigationBar.tsx
@@ -111,7 +111,7 @@ function NavigationBar() {
 
   return (
     <Sheet>
-      <SheetTrigger className="rounded-md p-2 hover:bg-slate-100 h-fit">
+      <SheetTrigger className="h-fit rounded-md p-2 hover:bg-slate-100">
         <IconMenu2 />
       </SheetTrigger>
       <SheetContent
@@ -127,6 +127,7 @@ function NavigationBar() {
         <NavigationItem title="지도" href="/" />
         <NavigationItem title="채팅" href="/chat" />
         <NavigationItem title="모각코" href="#" />
+        <NavigationItem title="업적" href="/achievements" />
       </SheetContent>
     </Sheet>
   );

--- a/app/_common/components/NavigationBar.tsx
+++ b/app/_common/components/NavigationBar.tsx
@@ -1,14 +1,8 @@
 "use client";
 
 import React from "react";
-import Link from "next/link";
-import {
-  IconBrandGithub,
-  IconChevronRight,
-  IconMenu2,
-} from "@tabler/icons-react";
+import { IconMenu2 } from "@tabler/icons-react";
 
-import { SignUpUser } from "@/app/signup/_type/signup";
 import {
   Sheet,
   SheetContent,
@@ -18,92 +12,8 @@ import {
 
 import { useAuthStore } from "../store/useAuthStore";
 import { Separator } from "../shadcn/ui/separator";
-import { Badge } from "../shadcn/ui/badge";
-import { Avatar, AvatarFallback, AvatarImage } from "../shadcn/ui/avatar";
-
-interface NavigationItemProps {
-  title: string;
-  href: string;
-}
-
-interface NavigationProfileProps {
-  user: Partial<SignUpUser>;
-}
-
-function NavigationItem(props: NavigationItemProps) {
-  const { title, href } = props;
-
-  return (
-    <div className="mb-2 space-y-2 px-2">
-      <Link href={href}>
-        <div className="flex items-center justify-between rounded-md p-3 hover:bg-slate-100">
-          <p className="text-lg">{title}</p>
-          <IconChevronRight />
-        </div>
-      </Link>
-      <Separator />
-    </div>
-  );
-}
-
-function NavigationProfile(props: NavigationProfileProps) {
-  const {
-    user: {
-      username,
-      achievementTitle,
-      githubUrl,
-      avatarUrl,
-      wantedJobs,
-      developLanguages,
-      bio,
-    },
-  } = props;
-
-  return (
-    <section className="flex flex-col gap-5 px-6 py-10 text-lg">
-      <main className="flex justify-evenly gap-5">
-        <aside className="flex items-center justify-center">
-          <Avatar className="h-32 w-32 border-4 border-slate-600">
-            <AvatarImage src={avatarUrl as string} alt="프로필 이미지" />
-            <AvatarFallback>{username}</AvatarFallback>
-          </Avatar>
-        </aside>
-        <aside className="flex flex-col justify-around  gap-1">
-          <div className="space-y-1">
-            <h1 className="flex items-center gap-1">
-              <p className="text-3xl font-semibold">{username}</p>
-              <Link href={githubUrl as string}>
-                <IconBrandGithub
-                  size={32}
-                  color="gray"
-                  className="mt-1 rounded-full p-2 hover:bg-slate-100"
-                />
-              </Link>
-            </h1>
-            <p className="text-left text-sm text-[#F76A6A]">
-              {achievementTitle}
-            </p>
-          </div>
-          <h2 className="max-h-20 min-h-fit overflow-hidden text-ellipsis border-l-4 pl-3 text-left">
-            {bio}
-          </h2>
-        </aside>
-      </main>
-      <footer className="space-y-2">
-        <div className="flex gap-1">
-          {wantedJobs && wantedJobs.map(job => <Badge key={job}>{job}</Badge>)}
-        </div>
-        <div className="flex gap-1">
-          {developLanguages &&
-            developLanguages.length > 0 &&
-            developLanguages.map(lang => (
-              <Badge key={lang.language}>{lang.language}</Badge>
-            ))}
-        </div>
-      </footer>
-    </section>
-  );
-}
+import NavigationProfile from "./NavigationProfile";
+import NavigationItem from "./NavigationItem";
 
 // TODO: 튜토리얼과 모각코 페이지를 만들어서 링크를 연결해주세요. 현재는 임시로 '#'로 연결
 function NavigationBar() {

--- a/app/_common/components/NavigationItem.tsx
+++ b/app/_common/components/NavigationItem.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import Link from "next/link";
+import { IconChevronRight } from "@tabler/icons-react";
+
+import { Separator } from "../shadcn/ui/separator";
+
+interface NavigationItemProps {
+  title: string;
+  href: string;
+}
+
+function NavigationItem(props: NavigationItemProps) {
+  const { title, href } = props;
+
+  return (
+    <div className="mb-2 space-y-2 px-2">
+      <Link href={href}>
+        <div className="flex items-center justify-between rounded-md p-3 hover:bg-slate-100">
+          <p className="text-lg">{title}</p>
+          <IconChevronRight />
+        </div>
+      </Link>
+      <Separator />
+    </div>
+  );
+}
+
+export default NavigationItem;

--- a/app/_common/components/NavigationProfile.tsx
+++ b/app/_common/components/NavigationProfile.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import { IconBrandGithub } from "@tabler/icons-react";
+
+import { SignUpUser } from "@/app/signup/_type/signup";
+
+import { Badge } from "../shadcn/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "../shadcn/ui/avatar";
+
+interface NavigationProfileProps {
+  user: Partial<SignUpUser>;
+}
+
+function NavigationProfile(props: NavigationProfileProps) {
+  const {
+    user: {
+      username,
+      achievementTitle,
+      githubUrl,
+      avatarUrl,
+      wantedJobs,
+      developLanguages,
+      bio,
+    },
+  } = props;
+
+  return (
+    <section className="flex flex-col gap-5 px-6 py-10 text-lg">
+      <main className="flex justify-evenly gap-5">
+        <aside className="flex items-center justify-center">
+          <Avatar className="h-32 w-32 border-4 border-slate-600">
+            <AvatarImage src={avatarUrl as string} alt="프로필 이미지" />
+            <AvatarFallback>{username}</AvatarFallback>
+          </Avatar>
+        </aside>
+        <aside className="flex flex-col justify-around  gap-1">
+          <div className="space-y-1">
+            <h1 className="flex items-center gap-1">
+              <p className="text-3xl font-semibold">{username}</p>
+              <Link href={githubUrl as string}>
+                <IconBrandGithub
+                  size={32}
+                  color="gray"
+                  className="mt-1 rounded-full p-2 hover:bg-slate-100"
+                />
+              </Link>
+            </h1>
+            <p className="text-left text-sm text-[#F76A6A]">
+              {achievementTitle}
+            </p>
+          </div>
+          <h2 className="max-h-20 min-h-fit overflow-hidden text-ellipsis border-l-4 pl-3 text-left">
+            {bio}
+          </h2>
+        </aside>
+      </main>
+      <footer className="space-y-2">
+        <div className="flex gap-1">
+          {wantedJobs && wantedJobs.map(job => <Badge key={job}>{job}</Badge>)}
+        </div>
+        <div className="flex gap-1">
+          {developLanguages &&
+            developLanguages.length > 0 &&
+            developLanguages.map(lang => (
+              <Badge key={lang.language}>{lang.language}</Badge>
+            ))}
+        </div>
+      </footer>
+    </section>
+  );
+}
+
+export default NavigationProfile;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,6 @@ import "dayjs/locale/ko";
 
 import { Toaster } from "./_common/shadcn/ui/toaster";
 import { ThemeProvider } from "./_common/components/theme-provider";
-import NavigationBar from "./_common/components/NavigationBar";
 import ClientProvider from "./_common/components/ClientProvider";
 
 import type { Metadata } from "next";
@@ -35,10 +34,7 @@ export default function RootLayout({
             enableSystem
             disableTransitionOnChange
           >
-            <section className="flex flex-row-reverse">
-              <NavigationBar />
               {children}
-            </section>
             <Toaster />
             <Sonner richColors position="bottom-center" />
           </ThemeProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import "dayjs/locale/ko";
 
 import { Toaster } from "./_common/shadcn/ui/toaster";
 import { ThemeProvider } from "./_common/components/theme-provider";
+import NavigationBar from "./_common/components/NavigationBar";
 import ClientProvider from "./_common/components/ClientProvider";
 
 import type { Metadata } from "next";
@@ -34,7 +35,10 @@ export default function RootLayout({
             enableSystem
             disableTransitionOnChange
           >
-            {children}
+            <section className="flex flex-row-reverse">
+              <NavigationBar />
+              {children}
+            </section>
             <Toaster />
             <Sonner richColors position="bottom-center" />
           </ThemeProvider>


### PR DESCRIPTION
# 📌 작업 내용

### AOS minimum
https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/101445377/53e05113-00d2-46d2-a794-9aec10615d18

### iPhone 14 pro max
https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/101445377/3c3c4895-b012-4b65-a693-0dffebd858da

### Desktop
https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/101445377/b714705d-ae17-4193-b714-56135f52836f


- [x] 네비게이션 바 구현
  - 사용자 정보는 API 호출 대신, `useAuthStore`로 사용 
  - Shadcn의 `Sheet`을 사용
# 🚦 특이 사항
<del>- `root layout`에 `NavigationBar`를 추가했습니다.</del>
<del>  - 로직 흐름을 원활하게 확인할 수 있도록 임시로 추가한 것이므로, 수정이 필요할 수 있습니다.</del>
```html
<html suppressHydrationWarning={true}>
      <link rel="manifest" href="/manifest.json" />
      <meta name="theme-color" content="#ffffff" />
      <body>
        <ClientProvider>
          <ThemeProvider
            attribute="class"
            defaultTheme="system"
            enableSystem
            disableTransitionOnChange
          >
            <section className="flex flex-row-reverse">
              <NavigationBar />
              {children}
            </section>
            <Toaster />
            <Sonner richColors position="bottom-center" />
          </ThemeProvider>
        </ClientProvider>
        <Toaster />
      </body>
    </html>
```
- ❌ 페이지를 확인해보니, 특정 페이지에서 레이아웃이 깨지는 현상을 발견했습니다. 그래서 일단은 `layout`에서 `<NavgiationBar/>`를 제거했습니다.
- 피그마 와이어프레임 최종 모음을 참고하여 구현했습니다.
  - 디자인의 통일성을 가져가기 위해, 일부 디자인은 변경하여 구현했습니다.
- 일부 메뉴 아이템에 Link 연결이 되어있지 않습니다. (페이지가 구현되지 않음)
- 구현되지 않은 부분이 있다면 말씀해주세요.
- 코드 이해 & 가독성이 떨어지는지 많은 피드백 부탁드립니다.

close #88 