### PR TITLE
[feat] 지역별 카드 조회 페이지네이션 로직 구현

### DIFF
--- a/app/(map)/_api/useGetCardList.ts
+++ b/app/(map)/_api/useGetCardList.ts
@@ -76,13 +76,16 @@ const useGetCardList = (regionCode: number) => {
 
   if (isProfileLoading || !profileList) {
     return {
-      cardList: { projectList, profileList: [] },
+      cardList: { projectList: projectList.pages[0].data, profileList: [] },
       ...defaultValue,
     };
   }
 
   return {
-    cardList: { projectList, profileList },
+    cardList: {
+      projectList: projectList.pages[0].data,
+      profileList: profileList.pages[0].data,
+    },
     ...defaultValue,
   };
 };

--- a/app/(map)/_api/useGetCardList.ts
+++ b/app/(map)/_api/useGetCardList.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 
 import { getProjectCard } from "@/app/_common/api/project";
@@ -8,7 +8,7 @@ import { formatRegionName } from "../_utils/formatRegionName";
 
 const useGetCardList = (regionCode: number) => {
   const region = formatRegionName(regionCode).toUpperCase();
-  const [isGetProfile, setIsGetProfile] = useState(false);
+  const isGetProfile = useRef(false);
 
   const {
     data: projectList,
@@ -24,7 +24,7 @@ const useGetCardList = (regionCode: number) => {
     initialPageParam: 0,
     getNextPageParam: lastPage => {
       if (!lastPage.hasNext) {
-        setIsGetProfile(true);
+        isGetProfile.current = true;
         return;
       }
       const cursorId = lastPage.data[lastPage.data.length - 1].projectId;
@@ -47,13 +47,13 @@ const useGetCardList = (regionCode: number) => {
     initialPageParam: 0,
     getNextPageParam: lastPage => {
       if (!lastPage.hasNext) {
-        setIsGetProfile(false);
+        isGetProfile.current = false;
         return;
       }
       const cursorId = lastPage.data[lastPage.data.length - 1].id;
       return cursorId;
     },
-    enabled: !!region && isGetProfile,
+    enabled: !!region && isGetProfile.current,
   });
 
   const defaultValue = {

--- a/app/(map)/_api/useGetCardList.ts
+++ b/app/(map)/_api/useGetCardList.ts
@@ -3,8 +3,6 @@ import { useQuery } from "@tanstack/react-query";
 import { getProjectCard } from "@/app/_common/api/project";
 import { getProfileCard } from "@/app/_common/api/profile";
 
-import { checkInstanceOfResponseError } from "@/app/_common/utils/checkInstanceOfResponseError";
-
 import { formatRegionName } from "../_utils/formatRegionName";
 
 // TODO: 페이지네이션 구현
@@ -32,23 +30,6 @@ const useGetCardList = (regionCode: number) => {
     return { data: undefined, isLoading: true, isError: false, error: null };
   }
 
-  if (checkInstanceOfResponseError(projectResponse.data)) {
-    return {
-      data: undefined,
-      isLoading: false,
-      isError: true,
-      error: projectResponse.data,
-    };
-  }
-
-  if (checkInstanceOfResponseError(profileResponse.data)) {
-    return {
-      data: undefined,
-      isLoading: false,
-      isError: true,
-      error: profileResponse.data,
-    };
-  }
 
   const { data: projectList } = projectResponse.data;
   const { data: profileList } = profileResponse.data;

--- a/app/(map)/_api/useGetCardList.ts
+++ b/app/(map)/_api/useGetCardList.ts
@@ -3,17 +3,13 @@ import { useQuery } from "@tanstack/react-query";
 import { getProjectCard } from "@/app/_common/api/project";
 import { getProfileCard } from "@/app/_common/api/profile";
 
-import REGION_CODE from "@/app/_common/constants/regionCode";
-
 import { checkInstanceOfResponseError } from "@/app/_common/utils/checkInstanceOfResponseError";
+
+import { formatRegionName } from "../_utils/formatRegionName";
 
 // TODO: 페이지네이션 구현
 const useGetCardList = (regionCode: number) => {
-  const regionName =
-    Object.keys(REGION_CODE).find(
-      region => REGION_CODE[region] === regionCode,
-    ) ?? "";
-  const region = regionName.toUpperCase();
+  const region = formatRegionName(regionCode).toUpperCase();
 
   const projectResponse = useQuery({
     queryKey: ["project-list", region] as const,

--- a/app/(map)/_api/useGetCardList.ts
+++ b/app/(map)/_api/useGetCardList.ts
@@ -1,44 +1,89 @@
-import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 import { getProjectCard } from "@/app/_common/api/project";
 import { getProfileCard } from "@/app/_common/api/profile";
 
 import { formatRegionName } from "../_utils/formatRegionName";
 
-// TODO: 페이지네이션 구현
 const useGetCardList = (regionCode: number) => {
   const region = formatRegionName(regionCode).toUpperCase();
+  const [isGetProfile, setIsGetProfile] = useState(false);
 
-  const projectResponse = useQuery({
+  const {
+    data: projectList,
+    isLoading: isProjectLoading,
+    fetchNextPage: fetchProject,
+    hasNextPage: hasNextProject,
+    isFetchingNextPage: isFetchingProject,
+  } = useInfiniteQuery({
     queryKey: ["project-list", region] as const,
-    queryFn: () => getProjectCard(region),
+    queryFn: ({ pageParam = 0 }) => {
+      return getProjectCard({ region, cursorId: pageParam });
+    },
+    initialPageParam: 0,
+    getNextPageParam: lastPage => {
+      if (!lastPage.hasNext) {
+        setIsGetProfile(true);
+        return;
+      }
+      const cursorId = lastPage.data[lastPage.data.length - 1].projectId;
+      return cursorId;
+    },
     enabled: !!region,
   });
 
-  const profileResponse = useQuery({
+  const {
+    data: profileList,
+    isLoading: isProfileLoading,
+    fetchNextPage: fetchProfile,
+    hasNextPage: hasNextProfile,
+    isFetchingNextPage: isFetchingProfile,
+  } = useInfiniteQuery({
     queryKey: ["profile-list", region] as const,
-    queryFn: () => getProfileCard(region),
-    enabled: !!region,
+    queryFn: ({ pageParam = 0 }) => {
+      return getProfileCard({ region, cursorId: pageParam });
+    },
+    initialPageParam: 0,
+    getNextPageParam: lastPage => {
+      if (!lastPage.hasNext) {
+        setIsGetProfile(false);
+        return;
+      }
+      const cursorId = lastPage.data[lastPage.data.length - 1].id;
+      return cursorId;
+    },
+    enabled: !!region && isGetProfile,
   });
 
-  if (
-    projectResponse.isLoading ||
-    !projectResponse.data ||
-    profileResponse.isLoading ||
-    !profileResponse.data
-  ) {
-    return { data: undefined, isLoading: true, isError: false, error: null };
+  const defaultValue = {
+    isProjectLoading,
+    fetchProject,
+    hasNextProject,
+    isFetchingProject,
+    isProfileLoading,
+    fetchProfile,
+    hasNextProfile,
+    isFetchingProfile,
+  };
+
+  if (isProjectLoading || !projectList) {
+    return {
+      cardList: { projectList: [], profileList: [] },
+      ...defaultValue,
+    };
   }
 
-
-  const { data: projectList } = projectResponse.data;
-  const { data: profileList } = profileResponse.data;
+  if (isProfileLoading || !profileList) {
+    return {
+      cardList: { projectList, profileList: [] },
+      ...defaultValue,
+    };
+  }
 
   return {
-    data: { projectList, profileList },
-    isLoading: false,
-    isError: false,
-    error: null,
+    cardList: { projectList, profileList },
+    ...defaultValue,
   };
 };
 

--- a/app/(map)/_api/useGetRank.ts
+++ b/app/(map)/_api/useGetRank.ts
@@ -2,30 +2,16 @@ import { useQuery } from "@tanstack/react-query";
 
 import { getRank } from "@/app/_common/api/project";
 
-import { checkInstanceOfResponseError } from "@/app/_common/utils/checkInstanceOfResponseError";
-
 const useGetRank = () => {
-  const response = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ["region-rank"],
     queryFn: getRank,
   });
-  const { data, isLoading } = response;
 
-  if (isLoading || !data) return { ...response };
-
-  if (checkInstanceOfResponseError(data)) {
-    return {
-      ...response,
-      data: undefined,
-      isError: true,
-      error: data,
-    };
-  } else {
-    return {
-      ...response,
-      data: data.densityRankByRegion.map(region => region.toLowerCase()),
-    };
-  }
+  return {
+    isRankLoading: isLoading,
+    rank: data?.densityRankByRegion.map(region => region.toLowerCase()),
+  };
 };
 
 export default useGetRank;

--- a/app/(map)/_components/CardList.tsx
+++ b/app/(map)/_components/CardList.tsx
@@ -17,16 +17,18 @@ interface Props {
 }
 
 function CardList({ cardList }: Props) {
+  const { projectList, profileList } = cardList;
+
   return (
     <CarouselContent>
-      {cardList.projectList.map((project: Project) => (
+      {projectList.map((project: Project) => (
         <CarouselItem key={project.projectId}>
           <div className="mb-20 flex items-center justify-center">
             <ProjectCardContainer project={project} />
           </div>
         </CarouselItem>
       ))}
-      {cardList.profileList.map((profile: Creator) => (
+      {profileList.map((profile: Creator) => (
         <CarouselItem key={profile.id}>
           <div className="mb-20 flex items-center justify-center">
             <ProfileCardItem profile={profile} />

--- a/app/(map)/_components/CardList.tsx
+++ b/app/(map)/_components/CardList.tsx
@@ -7,6 +7,8 @@ import {
 import { Project } from "@/app/_common/types/project";
 import { Creator } from "@/app/_common/types/profile";
 
+import ProfileCardItem from "./ProfileCardItem";
+
 interface Props {
   cardList: {
     projectList: Project[];
@@ -21,6 +23,13 @@ function CardList({ cardList }: Props) {
         <CarouselItem key={project.projectId}>
           <div className="mb-20 flex items-center justify-center">
             <ProjectCardContainer project={project} />
+          </div>
+        </CarouselItem>
+      ))}
+      {cardList.profileList.map((profile: Creator) => (
+        <CarouselItem key={profile.id}>
+          <div className="mb-20 flex items-center justify-center">
+            <ProfileCardItem profile={profile} />
           </div>
         </CarouselItem>
       ))}

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -112,9 +112,12 @@ function Map() {
 
   return (
     <div className="relative h-screen w-screen touch-none overflow-hidden">
-      {isRankLoading && (
-        <LoadingSpinner className="absolute bottom-0 left-0 right-0 top-0 z-10 flex h-full w-full place-content-center bg-white/40 backdrop-blur-sm" />
-      )}
+      <LoadingSpinner
+        className={cn(
+          "absolute bottom-0 left-0 right-0 top-0 z-10 flex h-full w-full place-content-center bg-white/40 backdrop-blur-sm transition-all duration-300",
+          isRankLoading ? "visible opacity-100" : "invisible opacity-0",
+        )}
+      />
       <div
         id="map-wrap"
         onClick={handleRegionClick}

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -2,12 +2,14 @@
 
 import { toast } from "sonner";
 import { MouseEvent, useEffect, useRef, useState } from "react";
+import { EmblaCarouselType } from "embla-carousel";
 
 import useQueryGeoAreaCode from "@/app/auth-mylocation/_hooks/useQueryGeoAreaCode";
 import { usePositionStore } from "@/app/_common/store/usePositionStore";
 import { cn } from "@/app/_common/shadcn/utils";
 import {
   Carousel,
+  CarouselApi,
   CarouselNext,
   CarouselPrevious,
 } from "@/app/_common/shadcn/ui/carousel";
@@ -37,7 +39,23 @@ function Map() {
   const { isAllowGPS } = usePositionStore();
   const {
     cardList,
+    fetchProject,
+    hasNextProject,
+    fetchProfile,
+    hasNextProfile,
   } = useGetCardList(regionCode);
+  const [api, setApi] = useState<CarouselApi>();
+
+  useEffect(() => {
+    if (!api) return;
+
+    api.on("select", (api: EmblaCarouselType) => {
+      if (api.canScrollNext()) return;
+
+      if (hasNextProject) fetchProject();
+      else if (!hasNextProject && hasNextProfile) fetchProfile();
+    });
+  }, [api, hasNextProject, hasNextProfile]);
 
   if (isGeoError) toast.error(geoError?.message);
 
@@ -111,6 +129,7 @@ function Map() {
           isListShow ? "visible opacity-100" : "invisible opacity-0",
         )}
         onClick={handleCancelCard}
+        setApi={setApi}
       >
         <div
           id="carousel-wrap"

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -32,12 +32,11 @@ function Map() {
   const [regionCode, setRegionCode] = useState(0);
   const previousRegion = useRef<SVGElement | null>(null);
   const [isListShow, setIsListShow] = useState(false);
-  const { data: rank, isError: isRankError, error: rankError } = useGetRank();
+  const { rank, isRankLoading } = useGetRank();
   const { isAllowGPS } = usePositionStore();
   const { data: cardList } = useGetCardList(regionCode);
 
   if (isGeoError) toast.error(geoError?.message);
-  if (isRankError) toast.error(rankError.message);
 
   useEffect(() => {
     if (areaCode) {

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -34,15 +34,10 @@ function Map() {
   const [isListShow, setIsListShow] = useState(false);
   const { data: rank, isError: isRankError, error: rankError } = useGetRank();
   const { isAllowGPS } = usePositionStore();
-  const {
-    data: cardList,
-    isError: isListError,
-    error: listError,
-  } = useGetCardList(regionCode);
+  const { data: cardList } = useGetCardList(regionCode);
 
   if (isGeoError) toast.error(geoError?.message);
   if (isRankError) toast.error(rankError.message);
-  if (isListError) toast.error(listError?.message);
 
   useEffect(() => {
     if (areaCode) {

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -60,12 +60,12 @@ function Map() {
   if (isGeoError) toast.error(geoError?.message);
 
   useEffect(() => {
-    if (areaCode) {
-      toast.info("내가 위치한 지역으로 이동합니다.");
-      setRegionCode(areaCode);
-      const regionName = formatRegionName(areaCode);
-      previousRegion.current = document.querySelector(`#${regionName}`);
-    }
+    if (!areaCode) return;
+
+    toast.info("내가 위치한 지역으로 이동합니다.");
+    setRegionCode(areaCode);
+    const regionName = formatRegionName(areaCode);
+    previousRegion.current = document.querySelector(`#${regionName}`);
   }, [areaCode]);
 
   const zoomOut = () => {

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -44,18 +44,18 @@ function Map() {
     fetchProfile,
     hasNextProfile,
   } = useGetCardList(regionCode);
-  const [api, setApi] = useState<CarouselApi>();
+  const [carouselApi, setCarouselApi] = useState<CarouselApi>();
 
   useEffect(() => {
-    if (!api) return;
+    if (!carouselApi) return;
 
-    api.on("select", (api: EmblaCarouselType) => {
-      if (api.canScrollNext()) return;
+    carouselApi.on("select", (carouselApi: EmblaCarouselType) => {
+      if (carouselApi.canScrollNext()) return;
 
       if (hasNextProject) fetchProject();
       else if (!hasNextProject && hasNextProfile) fetchProfile();
     });
-  }, [api, hasNextProject, hasNextProfile]);
+  }, [carouselApi, hasNextProject, hasNextProfile]);
 
   if (isGeoError) toast.error(geoError?.message);
 
@@ -129,7 +129,7 @@ function Map() {
           isListShow ? "visible opacity-100" : "invisible opacity-0",
         )}
         onClick={handleCancelCard}
-        setApi={setApi}
+        setApi={setCarouselApi}
       >
         <div
           id="carousel-wrap"

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -35,7 +35,9 @@ function Map() {
   const [isListShow, setIsListShow] = useState(false);
   const { rank, isRankLoading } = useGetRank();
   const { isAllowGPS } = usePositionStore();
-  const { data: cardList } = useGetCardList(regionCode);
+  const {
+    cardList,
+  } = useGetCardList(regionCode);
 
   if (isGeoError) toast.error(geoError?.message);
 
@@ -114,9 +116,8 @@ function Map() {
           id="carousel-wrap"
           className="flex h-full w-full flex-col items-center justify-center"
         >
-          {cardList &&
-          (cardList.projectList.length !== 0 ||
-            cardList.profileList.length !== 0) ? (
+          {cardList.projectList.length !== 0 ||
+          cardList.profileList.length !== 0 ? (
             <CardList cardList={cardList} />
           ) : (
             <EmptyCardList onClick={handleEmptyCardClose} />

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -17,6 +17,7 @@ import MapComponent from "@/app/_common/components/MapComponent";
 
 import REGION_CODE from "@/app/_common/constants/regionCode";
 
+import { formatRegionName } from "../_utils/formatRegionName";
 import useGetRank from "../_api/useGetRank";
 import useGetCardList from "../_api/useGetCardList";
 import EmptyCardList from "./EmptyCardList";
@@ -47,9 +48,7 @@ function Map() {
     if (areaCode) {
       toast.info("내가 위치한 지역으로 이동합니다.");
       setRegionCode(areaCode);
-      const regionName = Object.keys(REGION_CODE).find(
-        region => REGION_CODE[region] === areaCode,
-      );
+      const regionName = formatRegionName(areaCode);
       previousRegion.current = document.querySelector(`#${regionName}`);
     }
   }, [areaCode]);

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -112,7 +112,11 @@ function Map() {
 
   return (
     <div className="relative h-screen w-screen touch-none overflow-hidden">
-      {isRankLoading && <LoadingSpinner />}
+      {isRankLoading && (
+        <div className="absolute bottom-0 left-0 right-0 top-0 z-10 flex h-full w-full place-content-center bg-white/40 backdrop-blur-sm">
+          <LoadingSpinner />
+        </div>
+      )}
       <div
         id="map-wrap"
         onClick={handleRegionClick}

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -113,9 +113,7 @@ function Map() {
   return (
     <div className="relative h-screen w-screen touch-none overflow-hidden">
       {isRankLoading && (
-        <div className="absolute bottom-0 left-0 right-0 top-0 z-10 flex h-full w-full place-content-center bg-white/40 backdrop-blur-sm">
-          <LoadingSpinner />
-        </div>
+        <LoadingSpinner className="absolute bottom-0 left-0 right-0 top-0 z-10 flex h-full w-full place-content-center bg-white/40 backdrop-blur-sm" />
       )}
       <div
         id="map-wrap"

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -66,6 +66,7 @@ function Map() {
     setRegionCode(areaCode);
     const regionName = formatRegionName(areaCode);
     previousRegion.current = document.querySelector(`#${regionName}`);
+    setIsListShow(true);
   }, [areaCode]);
 
   const zoomOut = () => {

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -14,6 +14,7 @@ import {
 
 import WithSearchTokens from "@/app/_common/components/WithSearchTokens";
 import MapComponent from "@/app/_common/components/MapComponent";
+import LoadingSpinner from "@/app/_common/components/LoadingSpinner";
 
 import REGION_CODE from "@/app/_common/constants/regionCode";
 
@@ -91,6 +92,7 @@ function Map() {
 
   return (
     <div className="relative h-screen w-screen touch-none overflow-hidden">
+      {isRankLoading && <LoadingSpinner />}
       <div
         id="map-wrap"
         onClick={handleRegionClick}

--- a/app/(map)/_components/ProfileCardItem.tsx
+++ b/app/(map)/_components/ProfileCardItem.tsx
@@ -3,8 +3,6 @@ import Link from "next/link";
 import Image from "next/image";
 
 import ButtonFollow from "@/app/project/_components/ButtonFollow";
-import { cn } from "@/app/_common/shadcn/utils";
-import { Tabs, TabsContent } from "@/app/_common/shadcn/ui/tabs";
 import { Progress } from "@/app/_common/shadcn/ui/progress";
 import {
   Card,
@@ -35,21 +33,13 @@ function ProfileCardItem({ profile }: Props) {
   } = profile;
 
   return (
-    <Tabs defaultValue="card" className="h-[550px] w-[330px] sm:w-[450px]">
-      <TabsContent value="card" className="group h-full">
-        <div className={cn("relative h-full transition-all duration-500")}>
-          <Card
-            className={cn(
-              "glass-morphism absolute inset-0 left-0 top-0 border-none shadow-md",
-            )}
-          >
+    <div className="h-[550px] w-[330px] sm:w-[450px]">
+      <div className="h-full">
+        <div className="relative h-full">
+          <Card className="border-none shadow-md">
             <CardHeader className="px-5 pt-4">
               <CardDescription className="flex justify-end text-lg font-bold text-black">
-                <Link
-                  href={githubUrl}
-                  className="flex items-center"
-                  target="_blank"
-                >
+                <Link href={githubUrl} target="_blank">
                   @{githubId}
                 </Link>
               </CardDescription>
@@ -99,13 +89,13 @@ function ProfileCardItem({ profile }: Props) {
                 </div>
               </div>
             </CardContent>
-            <CardFooter className="flex items-center justify-between">
+            <CardFooter className="flex justify-end">
               <ButtonFollow />
             </CardFooter>
           </Card>
         </div>
-      </TabsContent>
-    </Tabs>
+      </div>
+    </div>
   );
 }
 

--- a/app/(map)/_components/ProfileCardItem.tsx
+++ b/app/(map)/_components/ProfileCardItem.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import Link from "next/link";
+import Image from "next/image";
+
+import ButtonFollow from "@/app/project/_components/ButtonFollow";
+import { cn } from "@/app/_common/shadcn/utils";
+import { Tabs, TabsContent } from "@/app/_common/shadcn/ui/tabs";
+import { Progress } from "@/app/_common/shadcn/ui/progress";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+} from "@/app/_common/shadcn/ui/card";
+import { Badge as Tag } from "@/app/_common/shadcn/ui/badge";
+
+import { Creator } from "@/app/_common/types/profile";
+
+interface Props {
+  profile: Creator;
+}
+
+function ProfileCardItem({ profile }: Props) {
+  const {
+    username,
+    githubId,
+    avatarUrl,
+    githubUrl,
+    bio,
+    jandiRate,
+    achievementTitle,
+    developLanguages,
+    wantedJobs,
+  } = profile;
+
+  return (
+    <Tabs defaultValue="card" className="h-[550px] w-[330px] sm:w-[450px]">
+      <TabsContent value="card" className="group h-full">
+        <div className={cn("relative h-full transition-all duration-500")}>
+          <Card
+            className={cn(
+              "glass-morphism absolute inset-0 left-0 top-0 border-none shadow-md",
+            )}
+          >
+            <CardHeader className="px-5 pt-4">
+              <CardDescription className="flex justify-end text-lg font-bold text-black">
+                <Link
+                  href={githubUrl}
+                  className="flex items-center"
+                  target="_blank"
+                >
+                  @{githubId}
+                </Link>
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col items-center gap-10">
+              <div className="flex flex-col items-center gap-5">
+                <div className="relative overflow-hidden rounded-xl shadow-lg">
+                  <Image
+                    src={avatarUrl}
+                    alt="프로필 이미지"
+                    width={150}
+                    height={150}
+                  />
+                </div>
+                <div className="flex flex-col items-center gap-[6px]">
+                  <div className="flex flex-col items-center gap-1 p-1">
+                    <h1 className="text-xl font-bold">{username}</h1>
+                    <h3 className="text-xs text-[#F76A6A]">
+                      {achievementTitle}
+                    </h3>
+                  </div>
+                  <p className="text-[#868686]">{bio}</p>
+                  <div className="flex flex-wrap items-center justify-center gap-1">
+                    {wantedJobs.map(job => (
+                      <Tag key={job}>{job}</Tag>
+                    ))}
+                  </div>
+                  <div className="flex flex-wrap items-center justify-center gap-1">
+                    {developLanguages.map(job => (
+                      <Tag key={job}>{job}</Tag>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <div className="flex w-full items-center justify-center">
+                <Image
+                  src="/images/grass.png"
+                  alt="잔디력"
+                  width={50}
+                  height={50}
+                />
+                <div className="mr-10 w-40">
+                  <Progress value={jandiRate} />
+                  <span className="text-xs text-[#868686]">
+                    {jandiRate * 100}%
+                  </span>
+                </div>
+              </div>
+            </CardContent>
+            <CardFooter className="flex items-center justify-between">
+              <ButtonFollow />
+            </CardFooter>
+          </Card>
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+export default ProfileCardItem;

--- a/app/(map)/_tests/formatRegionName.test.ts
+++ b/app/(map)/_tests/formatRegionName.test.ts
@@ -1,0 +1,20 @@
+import { formatRegionName } from "../_utils/formatRegionName";
+import REGION_CODE from "../../_common/constants/regionCode";
+
+describe("formatRegionName 함수 테스트", () => {
+  const mockRegionCode = Object.values(REGION_CODE);
+  const mockRegionName = Object.keys(REGION_CODE);
+
+  test.each(mockRegionCode)(
+    "법정구역코드를 보냈을 때 올바른 지역명으로 반환되는가",
+    regionCode => {
+      const index = mockRegionCode.indexOf(regionCode);
+      const regionName = formatRegionName(regionCode);
+      expect(regionName).toEqual(mockRegionName[index]);
+    },
+  );
+
+  test("존재하지 않는 법정구역코드거나 지역명이 undefined인 경우 빈 문자열을 반환하는가", () => {
+    expect(formatRegionName(0)).toStrictEqual("");
+  });
+});

--- a/app/(map)/_utils/formatRegionName.ts
+++ b/app/(map)/_utils/formatRegionName.ts
@@ -1,0 +1,9 @@
+import REGION_CODE from "../../_common/constants/regionCode";
+
+export const formatRegionName = (regionCode: number) => {
+  const regionName = Object.keys(REGION_CODE).find(
+    region => REGION_CODE[region] === regionCode,
+  );
+  if (!regionName) return "";
+  return regionName;
+};

--- a/app/_common/api/profile.ts
+++ b/app/_common/api/profile.ts
@@ -2,11 +2,18 @@ import { ResponseData } from "../types/response";
 import { Creator } from "../types/profile";
 import { instance } from "./instance";
 
-export const getProfileCard = async (
-  region: string,
-): Promise<ResponseData<Creator>> => {
+interface ProfileCardRequest {
+  region: string;
+  cursorId?: number;
+}
+
+export const getProfileCard = async ({
+  region,
+  cursorId,
+}: ProfileCardRequest) => {
+  const query = `${cursorId ? `cursorId=${cursorId}&` : ""}pageSize=5&sortOrder=ASC`;
   const { data } = await instance.get<ResponseData<Creator>>(
-    `/profiles/${region}?cursorId=1&pageSize=5&sortOrder=ASC`,
+    `/profiles/${region}?${query}`,
   );
   return data;
 };

--- a/app/_common/api/profile.ts
+++ b/app/_common/api/profile.ts
@@ -1,20 +1,12 @@
-import { AxiosError } from "axios";
-
-import { ResponseData, ResponseError } from "../types/response";
+import { ResponseData } from "../types/response";
 import { Creator } from "../types/profile";
 import { instance } from "./instance";
 
 export const getProfileCard = async (
   region: string,
-): Promise<ResponseData<Creator> | ResponseError | undefined> => {
-  try {
-    const { data } = await instance.get<ResponseData<Creator>>(
-      `/profiles/${region}?cursorId=1&pageSize=5&sortOrder=ASC`,
-    );
-    return data;
-  } catch (error) {
-    if (error instanceof AxiosError) {
-      return error.response?.data;
-    }
-  }
+): Promise<ResponseData<Creator>> => {
+  const { data } = await instance.get<ResponseData<Creator>>(
+    `/profiles/${region}?cursorId=1&pageSize=5&sortOrder=ASC`,
+  );
+  return data;
 };

--- a/app/_common/api/project.ts
+++ b/app/_common/api/project.ts
@@ -8,17 +8,9 @@ interface RegionRank {
   densityRankByRegion: string[];
 }
 
-export const getRank = async (): Promise<
-  RegionRank | ResponseError | undefined
-> => {
-  try {
-    const { data } = await instance.get<RegionRank>("/projects/density/rank");
-    return data;
-  } catch (error) {
-    if (error instanceof AxiosError) {
-      return error.response?.data;
-    }
-  }
+export const getRank = async (): Promise<RegionRank> => {
+  const { data } = await instance.get<RegionRank>("/projects/density/rank");
+  return data;
 };
 
 export const getProjectCard = async (

--- a/app/_common/api/project.ts
+++ b/app/_common/api/project.ts
@@ -23,15 +23,9 @@ export const getRank = async (): Promise<
 
 export const getProjectCard = async (
   region: string,
-): Promise<ResponseData<Project> | ResponseError | undefined> => {
-  try {
-    const { data } = await instance.get<ResponseData<Project>>(
-      `/projects/${region}?cursorId=1&pageSize=5&sortOrder=ASC`,
-    );
-    return data;
-  } catch (error) {
-    if (error instanceof AxiosError) {
-      return error.response?.data;
-    }
-  }
+): Promise<ResponseData<Project>> => {
+  const { data } = await instance.get<ResponseData<Project>>(
+    `/projects/${region}?cursorId=1&pageSize=5&sortOrder=ASC`,
+  );
+  return data;
 };

--- a/app/_common/api/project.ts
+++ b/app/_common/api/project.ts
@@ -1,6 +1,4 @@
-import { AxiosError } from "axios";
-
-import { ResponseData, ResponseError } from "../types/response";
+import { ResponseData } from "../types/response";
 import { Project } from "../types/project";
 import { instance } from "./instance";
 
@@ -13,11 +11,18 @@ export const getRank = async (): Promise<RegionRank> => {
   return data;
 };
 
-export const getProjectCard = async (
-  region: string,
-): Promise<ResponseData<Project>> => {
+interface ProjectCardRequest {
+  region: string;
+  cursorId?: number;
+}
+
+export const getProjectCard = async ({
+  region,
+  cursorId,
+}: ProjectCardRequest) => {
+  const query = `${cursorId ? `cursorId=${cursorId}&` : ""}pageSize=5&sortOrder=ASC`;
   const { data } = await instance.get<ResponseData<Project>>(
-    `/projects/${region}?cursorId=1&pageSize=5&sortOrder=ASC`,
+    `/projects/${region}?${query}`,
   );
   return data;
 };

--- a/app/_common/components/LoadingSpinner.tsx
+++ b/app/_common/components/LoadingSpinner.tsx
@@ -5,16 +5,19 @@ import animation from "../assets/spinner-animation.json";
 interface LoadingSpinnerProps {
   width?: string;
   height?: string;
+  className?: string;
 }
 
-function LoadingSpinner({ width, height }: LoadingSpinnerProps) {
+function LoadingSpinner({ width, height, className }: LoadingSpinnerProps) {
   return (
-    <Lottie
-      play
-      animationData={animation}
-      speed={0.5}
-      style={{ width, height }}
-    />
+    <div className={className}>
+      <Lottie
+        play
+        animationData={animation}
+        speed={0.5}
+        style={{ width, height }}
+      />
+    </div>
   );
 }
 

--- a/app/_common/components/MapComponent.tsx
+++ b/app/_common/components/MapComponent.tsx
@@ -1,9 +1,9 @@
 import { useEffect } from "react";
 
+import { formatRegionName } from "@/app/(map)/_utils/formatRegionName";
 import RankInfo from "@/app/(map)/_components/RankInfo";
 
 import "@/app/(map)/_styles/map.css";
-import REGION_CODE from "../constants/regionCode";
 
 const strokeColor = "white";
 const textColor = "black";
@@ -33,9 +33,7 @@ function MapComponent({ regionCode, regionRank }: Props) {
 
   const zoomInRegion = (regionCode: number) => {
     const map = document.querySelector("#map-wrap") as HTMLDivElement;
-    const regionName = Object.keys(REGION_CODE).find(
-      region => REGION_CODE[region] === regionCode,
-    );
+    const regionName = formatRegionName(regionCode);
     const region = document.querySelector(`#${regionName}`);
 
     if (!region || !map) return;

--- a/app/project/_components/ButtonFollow.tsx
+++ b/app/project/_components/ButtonFollow.tsx
@@ -1,11 +1,10 @@
-import React from "react";
 import { IconHeartFilled } from "@tabler/icons-react";
 
 import { Button } from "@/app/_common/shadcn/ui/button";
 
 function ButtonFollow() {
   return (
-    <Button className="mt-0 flex items-center justify-center p-2 text-[#FF0000]">
+    <Button className="mt-0 flex items-center justify-center bg-[#F9679C] p-2 text-white">
       <IconHeartFilled />
     </Button>
   );

--- a/app/signup/_components/SignupForm.tsx
+++ b/app/signup/_components/SignupForm.tsx
@@ -61,9 +61,11 @@ function SignupForm() {
 
   if (!userData || !languages)
     return (
-      <div className="grid h-screen w-screen place-content-center">
-        <LoadingSpinner width="100" height="100" />
-      </div>
+      <LoadingSpinner
+        width="100"
+        height="100"
+        className="grid h-screen w-screen place-content-center"
+      />
     );
 
   return (


### PR DESCRIPTION
# 📌 작업 내용
- 프로젝트, 프로필 카드 조회, 밀도 순위에 에러 처리가 필요없으므로 에러 핸들링 코드 삭제 (추후 필요하다면 다시 추가하겠습니다)
- 로딩 시 `LoadingSpinner` 컴포넌트 적용
- 백엔드 api 수정으로 구역별 프로젝트/프로필 카드 초기 조회 때 cursorId 안 들어가도록 쿼리 수정
- `useInfiniteQuery`를 이용하여 무한 스크롤 구현
    - `hasNext` 프로퍼티를 사용하여 프로젝트 조회할 때 다음에 조회할 것이 없으면 프로필을 조회하도록 구현
    - **현재 에러는 나지 않도록 데이터 반환값을 0번째 인덱스로 하도록 고정해두었지만, 데이터가 부족해서 충분한 테스트를 못한 상태이기 때문에 데이터 반환값을 추후 수정해야 합니다.**
    ```ts
      cardList: {
          projectList: projectList.pages[0].data,
          profileList: profileList.pages[0].data,
      },
    ```
    이렇게 처리해놔서 에러가 나지는 않지만 테스트를 통해 반환값을 수정할 예정입니다. 로직을 수정해야할 수도 있습니다!

# 🚦 특이 사항
- 무한스크롤 구현에서 로직적인 문제가 있는지 궁금합니다.
- 컨벤션이나 명칭이 알아보기 쉬운지, 로직이 쉽게 이해가는지 궁금합니다.

close #68