### PR TITLE
[feat] 프로필 카드 찜하기 구현

### DIFF
--- a/app/(map)/_api/useGetCardList.ts
+++ b/app/(map)/_api/useGetCardList.ts
@@ -50,7 +50,7 @@ const useGetCardList = (regionCode: number) => {
         isGetProfile.current = false;
         return;
       }
-      const cursorId = lastPage.data[lastPage.data.length - 1].id;
+      const cursorId = lastPage.data[lastPage.data.length - 1].response.id;
       return cursorId;
     },
     enabled: !!region && isGetProfile.current,

--- a/app/(map)/_api/useToggleLikeProfile.ts
+++ b/app/(map)/_api/useToggleLikeProfile.ts
@@ -6,10 +6,11 @@ import { useMutation } from "@tanstack/react-query";
 import { deleteLikeProfile, postLikeProfile } from "@/app/_common/api/profile";
 
 import { ResponseError } from "@/app/_common/types/response";
+import { ProfileLikeInfo } from "@/app/_common/types/profile";
 
 interface ToggleLike {
   isLiked: boolean;
-  likeInfo: { senderId: number; receiverId: number };
+  likeInfo: ProfileLikeInfo;
 }
 
 const useToggleLikeProfile = () => {

--- a/app/(map)/_api/useToggleLikeProfile.ts
+++ b/app/(map)/_api/useToggleLikeProfile.ts
@@ -6,6 +6,11 @@ import { deleteLikeProfile, postLikeProfile } from "@/app/_common/api/profile";
 
 import { ResponseError } from "@/app/_common/types/response";
 
+interface ToggleLike {
+  isLiked: boolean;
+  likeInfo: { senderId: number; receiverId: number };
+}
+
 const useToggleLikeProfile = () => {
   const { mutate: addLikeProfile } = useMutation({
     mutationFn: postLikeProfile,
@@ -31,7 +36,12 @@ const useToggleLikeProfile = () => {
     throwOnError: false,
   });
 
-  return { addLikeProfile, cancelLikeProfile };
+  const toggleLikeProfile = ({ isLiked, likeInfo }: ToggleLike) => {
+    if (isLiked) cancelLikeProfile(likeInfo);
+    else addLikeProfile(likeInfo);
+  };
+
+  return { toggleLikeProfile };
 };
 
 export default useToggleLikeProfile;

--- a/app/(map)/_api/useToggleLikeProfile.ts
+++ b/app/(map)/_api/useToggleLikeProfile.ts
@@ -1,29 +1,34 @@
 import { toast } from "sonner";
+import { AxiosError } from "axios";
 import { useMutation } from "@tanstack/react-query";
 
 import { deleteLikeProfile, postLikeProfile } from "@/app/_common/api/profile";
 
+import { ResponseError } from "@/app/_common/types/response";
+
 const useToggleLikeProfile = () => {
   const { mutate: addLikeProfile } = useMutation({
     mutationFn: postLikeProfile,
-    onSuccess: (data, variables, context) => {
-      console.log("onSuccess", data, variables, context);
+    onSuccess: () => {
       toast.success("찔러보기에 성공했습니다.");
     },
-    onError: (error, variables, context) => {
-      console.log("onError", error, variables, context);
-      toast.error("찔러보기에 성공했습니다.");
+    onError: (error: AxiosError<ResponseError>) => {
+      if (error.response) toast.error(error.response.data.message);
+      else toast.error("찔러보기에 실패했습니다, 다시 시도해주세요.");
     },
+    throwOnError: false,
   });
 
   const { mutate: cancelLikeProfile } = useMutation({
     mutationFn: deleteLikeProfile,
-    onSuccess: (data, variables, context) => {
-      console.log(data, variables, context);
+    onSuccess: () => {
+      toast.success("찔러보기에 삭제에 성공했습니다.");
     },
-    onError: (error, variables, context) => {
-      console.log(error, variables, context);
+    onError: (error: AxiosError<ResponseError>) => {
+      if (error.response) toast.error(error.response.data.message);
+      else toast.error("찔러보기 삭제에 실패했습니다, 다시 시도해주세요.");
     },
+    throwOnError: false,
   });
 
   return { addLikeProfile, cancelLikeProfile };

--- a/app/(map)/_api/useToggleLikeProfile.ts
+++ b/app/(map)/_api/useToggleLikeProfile.ts
@@ -1,0 +1,32 @@
+import { toast } from "sonner";
+import { useMutation } from "@tanstack/react-query";
+
+import { deleteLikeProfile, postLikeProfile } from "@/app/_common/api/profile";
+
+const useToggleLikeProfile = () => {
+  const { mutate: addLikeProfile } = useMutation({
+    mutationFn: postLikeProfile,
+    onSuccess: (data, variables, context) => {
+      console.log("onSuccess", data, variables, context);
+      toast.success("찔러보기에 성공했습니다.");
+    },
+    onError: (error, variables, context) => {
+      console.log("onError", error, variables, context);
+      toast.error("찔러보기에 성공했습니다.");
+    },
+  });
+
+  const { mutate: cancelLikeProfile } = useMutation({
+    mutationFn: deleteLikeProfile,
+    onSuccess: (data, variables, context) => {
+      console.log(data, variables, context);
+    },
+    onError: (error, variables, context) => {
+      console.log(error, variables, context);
+    },
+  });
+
+  return { addLikeProfile, cancelLikeProfile };
+};
+
+export default useToggleLikeProfile;

--- a/app/(map)/_api/useToggleLikeProfile.ts
+++ b/app/(map)/_api/useToggleLikeProfile.ts
@@ -18,7 +18,7 @@ const useToggleLikeProfile = () => {
   const { mutate: addLikeProfile } = useMutation({
     mutationFn: postLikeProfile,
     onSuccess: () => {
-      toast.success("찔러보기에 성공했습니다.");
+      toast.success("찔러보기 요청을 완료했습니다.");
       setIsLiked(true);
     },
     onError: (error: AxiosError<ResponseError>) => {
@@ -31,7 +31,7 @@ const useToggleLikeProfile = () => {
   const { mutate: cancelLikeProfile } = useMutation({
     mutationFn: deleteLikeProfile,
     onSuccess: () => {
-      toast.success("찔러보기에 삭제에 성공했습니다.");
+      toast.success("찔러보기 삭제를 완료했습니다.");
       setIsLiked(false);
     },
     onError: (error: AxiosError<ResponseError>) => {

--- a/app/(map)/_api/useToggleLikeProfile.ts
+++ b/app/(map)/_api/useToggleLikeProfile.ts
@@ -1,4 +1,5 @@
 import { toast } from "sonner";
+import { useState } from "react";
 import { AxiosError } from "axios";
 import { useMutation } from "@tanstack/react-query";
 
@@ -12,10 +13,13 @@ interface ToggleLike {
 }
 
 const useToggleLikeProfile = () => {
+  const [isLiked, setIsLiked] = useState<boolean | null>(null);
+
   const { mutate: addLikeProfile } = useMutation({
     mutationFn: postLikeProfile,
     onSuccess: () => {
       toast.success("찔러보기에 성공했습니다.");
+      setIsLiked(true);
     },
     onError: (error: AxiosError<ResponseError>) => {
       if (error.response) toast.error(error.response.data.message);
@@ -28,6 +32,7 @@ const useToggleLikeProfile = () => {
     mutationFn: deleteLikeProfile,
     onSuccess: () => {
       toast.success("찔러보기에 삭제에 성공했습니다.");
+      setIsLiked(false);
     },
     onError: (error: AxiosError<ResponseError>) => {
       if (error.response) toast.error(error.response.data.message);
@@ -41,7 +46,7 @@ const useToggleLikeProfile = () => {
     else addLikeProfile(likeInfo);
   };
 
-  return { toggleLikeProfile };
+  return { toggleLikeProfile, isLiked };
 };
 
 export default useToggleLikeProfile;

--- a/app/(map)/_components/CardList.tsx
+++ b/app/(map)/_components/CardList.tsx
@@ -5,14 +5,14 @@ import {
 } from "@/app/_common/shadcn/ui/carousel";
 
 import { Project } from "@/app/_common/types/project";
-import { Creator } from "@/app/_common/types/profile";
+import { Profile } from "@/app/_common/types/profile";
 
 import ProfileCardItem from "./ProfileCardItem";
 
 interface Props {
   cardList: {
     projectList: Project[];
-    profileList: Creator[];
+    profileList: Profile[];
   };
 }
 
@@ -28,8 +28,8 @@ function CardList({ cardList }: Props) {
           </div>
         </CarouselItem>
       ))}
-      {profileList.map((profile: Creator) => (
-        <CarouselItem key={profile.id}>
+      {profileList.map((profile: Profile) => (
+        <CarouselItem key={profile.response.id}>
           <div className="mb-20 flex items-center justify-center">
             <ProfileCardItem profile={profile} />
           </div>

--- a/app/(map)/_components/ProfileCardItem.tsx
+++ b/app/(map)/_components/ProfileCardItem.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Link from "next/link";
 import Image from "next/image";
 
-import ButtonFollow from "@/app/project/_components/ButtonFollow";
+import ButtonLike from "@/app/project/_components/ButtonLike";
 import { Progress } from "@/app/_common/shadcn/ui/progress";
 import {
   Card,
@@ -90,7 +90,7 @@ function ProfileCardItem({ profile }: Props) {
               </div>
             </CardContent>
             <CardFooter className="flex justify-end">
-              <ButtonFollow />
+              <ButtonLike />
             </CardFooter>
           </Card>
         </div>

--- a/app/(map)/_components/ProfileCardItem.tsx
+++ b/app/(map)/_components/ProfileCardItem.tsx
@@ -41,12 +41,14 @@ function ProfileCardItem({ profile }: Props) {
     requestYn: isLiked,
   } = profile;
   const { user } = useAuthStore();
-  const { addLikeProfile, cancelLikeProfile } = useToggleLikeProfile();
+  const { toggleLikeProfile } = useToggleLikeProfile();
 
   const handleToggleButton = () => {
     if (!user) return;
-    if (isLiked) cancelLikeProfile({ senderId: user.id, receiverId: id });
-    else addLikeProfile({ senderId: user.id, receiverId: id });
+    toggleLikeProfile({
+      isLiked,
+      likeInfo: { senderId: user.id, receiverId: id },
+    });
   };
 
   return (

--- a/app/(map)/_components/ProfileCardItem.tsx
+++ b/app/(map)/_components/ProfileCardItem.tsx
@@ -38,15 +38,15 @@ function ProfileCardItem({ profile }: Props) {
       developLanguages,
       wantedJobs,
     },
-    requestYn: isLiked,
+    requestYn,
   } = profile;
   const { user } = useAuthStore();
-  const { toggleLikeProfile } = useToggleLikeProfile();
+  const { toggleLikeProfile, isLiked } = useToggleLikeProfile();
 
   const handleToggleButton = () => {
     if (!user) return;
     toggleLikeProfile({
-      isLiked,
+      isLiked: isLiked ?? requestYn,
       likeInfo: { senderId: user.id, receiverId: id },
     });
   };
@@ -109,7 +109,10 @@ function ProfileCardItem({ profile }: Props) {
               </div>
             </CardContent>
             <CardFooter className="flex justify-end">
-              <ButtonLike onClick={handleToggleButton} isLiked={isLiked} />
+              <ButtonLike
+                onClick={handleToggleButton}
+                isLiked={isLiked ?? requestYn}
+              />
             </CardFooter>
           </Card>
         </div>

--- a/app/(map)/_components/ProfileCardItem.tsx
+++ b/app/(map)/_components/ProfileCardItem.tsx
@@ -44,6 +44,7 @@ function ProfileCardItem({ profile }: Props) {
   const { addLikeProfile } = useToggleLikeProfile();
 
   const handleToggleButton = () => {
+    if (!user) return;
     setIsLiked(prev => !prev);
     addLikeProfile({ senderId: user.id, receiverId: id });
   };

--- a/app/(map)/_components/ProfileCardItem.tsx
+++ b/app/(map)/_components/ProfileCardItem.tsx
@@ -1,8 +1,11 @@
-import React from "react";
+"use client";
+
+import React, { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 
 import ButtonLike from "@/app/project/_components/ButtonLike";
+import { useAuthStore } from "@/app/_common/store/useAuthStore";
 import { Progress } from "@/app/_common/shadcn/ui/progress";
 import {
   Card,
@@ -15,12 +18,15 @@ import { Badge as Tag } from "@/app/_common/shadcn/ui/badge";
 
 import { Creator } from "@/app/_common/types/profile";
 
+import useToggleLikeProfile from "../_api/useToggleLikeProfile";
+
 interface Props {
   profile: Creator;
 }
 
 function ProfileCardItem({ profile }: Props) {
   const {
+    id,
     username,
     githubId,
     avatarUrl,
@@ -31,6 +37,14 @@ function ProfileCardItem({ profile }: Props) {
     developLanguages,
     wantedJobs,
   } = profile;
+  const [isLiked, setIsLiked] = useState(false);
+  const { user } = useAuthStore();
+  const { addLikeProfile } = useToggleLikeProfile();
+
+  const handleToggleButton = () => {
+    setIsLiked(prev => !prev);
+    addLikeProfile({ senderId: user.id, receiverId: id });
+  };
 
   return (
     <div className="h-[550px] w-[330px] sm:w-[450px]">
@@ -90,7 +104,7 @@ function ProfileCardItem({ profile }: Props) {
               </div>
             </CardContent>
             <CardFooter className="flex justify-end">
-              <ButtonLike />
+              <ButtonLike onClick={handleToggleButton} isLiked={isLiked} />
             </CardFooter>
           </Card>
         </div>

--- a/app/(map)/_components/ProfileCardItem.tsx
+++ b/app/(map)/_components/ProfileCardItem.tsx
@@ -27,7 +27,7 @@ interface Props {
 function ProfileCardItem({ profile }: Props) {
   const {
     response: {
-      id,
+      id: receiverId,
       username,
       githubId,
       avatarUrl,
@@ -47,7 +47,7 @@ function ProfileCardItem({ profile }: Props) {
     if (!user) return;
     toggleLikeProfile({
       isLiked: isLiked ?? requestYn,
-      likeInfo: { senderId: user.id, receiverId: id },
+      likeInfo: { senderId: user.id, receiverId },
     });
   };
 

--- a/app/(map)/_components/ProfileCardItem.tsx
+++ b/app/(map)/_components/ProfileCardItem.tsx
@@ -38,7 +38,7 @@ function ProfileCardItem({ profile }: Props) {
       developLanguages,
       wantedJobs,
     },
-    requestYn,
+    requestYn: isAlreadyLiked,
   } = profile;
   const { user } = useAuthStore();
   const { toggleLikeProfile, isLiked } = useToggleLikeProfile();
@@ -46,7 +46,7 @@ function ProfileCardItem({ profile }: Props) {
   const handleToggleButton = () => {
     if (!user) return;
     toggleLikeProfile({
-      isLiked: isLiked ?? requestYn,
+      isLiked: isLiked ?? isAlreadyLiked,
       likeInfo: { senderId: user.id, receiverId },
     });
   };
@@ -111,7 +111,7 @@ function ProfileCardItem({ profile }: Props) {
             <CardFooter className="flex justify-end">
               <ButtonLike
                 onClick={handleToggleButton}
-                isLiked={isLiked ?? requestYn}
+                isLiked={isLiked ?? isAlreadyLiked}
               />
             </CardFooter>
           </Card>

--- a/app/(map)/_components/ProfileCardItem.tsx
+++ b/app/(map)/_components/ProfileCardItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React from "react";
 import Link from "next/link";
 import Image from "next/image";
 
@@ -38,15 +38,15 @@ function ProfileCardItem({ profile }: Props) {
       developLanguages,
       wantedJobs,
     },
+    requestYn: isLiked,
   } = profile;
-  const [isLiked, setIsLiked] = useState(false);
   const { user } = useAuthStore();
-  const { addLikeProfile } = useToggleLikeProfile();
+  const { addLikeProfile, cancelLikeProfile } = useToggleLikeProfile();
 
   const handleToggleButton = () => {
     if (!user) return;
-    setIsLiked(prev => !prev);
-    addLikeProfile({ senderId: user.id, receiverId: id });
+    if (isLiked) cancelLikeProfile({ senderId: user.id, receiverId: id });
+    else addLikeProfile({ senderId: user.id, receiverId: id });
   };
 
   return (

--- a/app/(map)/_components/ProfileCardItem.tsx
+++ b/app/(map)/_components/ProfileCardItem.tsx
@@ -16,26 +16,28 @@ import {
 } from "@/app/_common/shadcn/ui/card";
 import { Badge as Tag } from "@/app/_common/shadcn/ui/badge";
 
-import { Creator } from "@/app/_common/types/profile";
+import { Profile } from "@/app/_common/types/profile";
 
 import useToggleLikeProfile from "../_api/useToggleLikeProfile";
 
 interface Props {
-  profile: Creator;
+  profile: Profile;
 }
 
 function ProfileCardItem({ profile }: Props) {
   const {
-    id,
-    username,
-    githubId,
-    avatarUrl,
-    githubUrl,
-    bio,
-    jandiRate,
-    achievementTitle,
-    developLanguages,
-    wantedJobs,
+    response: {
+      id,
+      username,
+      githubId,
+      avatarUrl,
+      githubUrl,
+      bio,
+      jandiRate,
+      achievementTitle,
+      developLanguages,
+      wantedJobs,
+    },
   } = profile;
   const [isLiked, setIsLiked] = useState(false);
   const { user } = useAuthStore();

--- a/app/_common/api/profile.ts
+++ b/app/_common/api/profile.ts
@@ -9,12 +9,17 @@ interface ProfileCardRequest {
   cursorId?: number;
 }
 
+interface ProfileCardResponse {
+  response: Creator;
+  requestYn: boolean;
+}
+
 export const getProfileCard = async ({
   region,
   cursorId,
 }: ProfileCardRequest) => {
   const query = `${cursorId ? `cursorId=${cursorId}&` : ""}pageSize=5&sortOrder=ASC`;
-  const { data } = await instance.get<ResponseData<Creator>>(
+  const { data } = await instance.get<ResponseData<ProfileCardResponse>>(
     `/profiles/${region}?${query}`,
   );
   return data;
@@ -42,7 +47,8 @@ export const getReceiveLikeCount = async (
 
   try {
     const { data } = await instance.get<Like>(
-      `/profiles/${userId}/receive/like`,);
+      `/profiles/${userId}/receive/like`,
+    );
     return data;
   } catch (error) {
     if (error instanceof AxiosError) {

--- a/app/_common/api/profile.ts
+++ b/app/_common/api/profile.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from "axios";
 
 import { ResponseData } from "../types/response";
-import { Creator, Like } from "../types/profile";
+import { Like, Profile } from "../types/profile";
 import { instance } from "./instance";
 
 interface ProfileCardRequest {
@@ -9,17 +9,12 @@ interface ProfileCardRequest {
   cursorId?: number;
 }
 
-interface ProfileCardResponse {
-  response: Creator;
-  requestYn: boolean;
-}
-
 export const getProfileCard = async ({
   region,
   cursorId,
 }: ProfileCardRequest) => {
   const query = `${cursorId ? `cursorId=${cursorId}&` : ""}pageSize=5&sortOrder=ASC`;
-  const { data } = await instance.get<ResponseData<ProfileCardResponse>>(
+  const { data } = await instance.get<ResponseData<Profile>>(
     `/profiles/${region}?${query}`,
   );
   return data;

--- a/app/_common/api/profile.ts
+++ b/app/_common/api/profile.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from "axios";
 
 import { ResponseData } from "../types/response";
-import { Like, Profile } from "../types/profile";
+import { Like, Profile, ProfileLikeInfo } from "../types/profile";
 import { instance } from "./instance";
 
 interface ProfileCardRequest {
@@ -52,11 +52,6 @@ export const getReceiveLikeCount = async (
   }
 };
 
-interface ProfileLikeBody {
-  senderId: number;
-  receiverId: number;
-}
-
 interface ProfileLikeResponse {
   id: number;
 }
@@ -64,7 +59,7 @@ interface ProfileLikeResponse {
 export const postLikeProfile = async ({
   senderId,
   receiverId,
-}: ProfileLikeBody) => {
+}: ProfileLikeInfo) => {
   const { data } = await instance.post<ProfileLikeResponse>("/profiles/like", {
     senderId,
     receiverId,
@@ -75,6 +70,6 @@ export const postLikeProfile = async ({
 export const deleteLikeProfile = async ({
   senderId,
   receiverId,
-}: ProfileLikeBody) => {
+}: ProfileLikeInfo) => {
   await instance.delete("/profiles/like", { data: { senderId, receiverId } });
 };

--- a/app/_common/api/profile.ts
+++ b/app/_common/api/profile.ts
@@ -76,5 +76,5 @@ export const deleteLikeProfile = async ({
   senderId,
   receiverId,
 }: ProfileLikeBody) => {
-  await instance.delete("/profiles/like", { senderId, receiverId });
+  await instance.delete("/profiles/like", { data: { senderId, receiverId } });
 };

--- a/app/_common/api/profile.ts
+++ b/app/_common/api/profile.ts
@@ -1,6 +1,6 @@
 import { AxiosError } from "axios";
 
-import { ResponseData, ResponseError } from "../types/response";
+import { ResponseData } from "../types/response";
 import { Creator, Like } from "../types/profile";
 import { instance } from "./instance";
 
@@ -50,6 +50,7 @@ export const getReceiveLikeCount = async (
     }
   }
 };
+
 interface ProfileLikeBody {
   senderId: number;
   receiverId: number;
@@ -62,34 +63,17 @@ interface ProfileLikeResponse {
 export const postLikeProfile = async ({
   senderId,
   receiverId,
-}: ProfileLikeBody): Promise<
-  ProfileLikeResponse | ResponseError | undefined
-> => {
-  try {
-    const { data } = await instance.post<ProfileLikeResponse>(
-      "/profiles/like",
-      {
-        senderId,
-        receiverId,
-      },
-    );
-    return data;
-  } catch (error) {
-    if (error instanceof AxiosError) {
-      return error.response?.data;
-    }
-  }
+}: ProfileLikeBody) => {
+  const { data } = await instance.post<ProfileLikeResponse>("/profiles/like", {
+    senderId,
+    receiverId,
+  });
+  return data;
 };
 
 export const deleteLikeProfile = async ({
   senderId,
   receiverId,
-}: ProfileLikeBody): Promise<ResponseError | undefined> => {
-  try {
-    await instance.delete("/profiles/like", { senderId, receiverId });
-  } catch (error) {
-    if (error instanceof AxiosError) {
-      return error.response?.data;
-    }
-  }
+}: ProfileLikeBody) => {
+  await instance.delete("/profiles/like", { senderId, receiverId });
 };

--- a/app/_common/api/profile.ts
+++ b/app/_common/api/profile.ts
@@ -1,6 +1,6 @@
 import { AxiosError } from "axios";
 
-import { ResponseData } from "../types/response";
+import { ResponseData, ResponseError } from "../types/response";
 import { Creator, Like } from "../types/profile";
 import { instance } from "./instance";
 
@@ -42,9 +42,51 @@ export const getReceiveLikeCount = async (
 
   try {
     const { data } = await instance.get<Like>(
-      `/profiles/${userId}/receive/like`,
+      `/profiles/${userId}/receive/like`,);
+    return data;
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return error.response?.data;
+    }
+  }
+};
+interface ProfileLikeBody {
+  senderId: number;
+  receiverId: number;
+}
+
+interface ProfileLikeResponse {
+  id: number;
+}
+
+export const postLikeProfile = async ({
+  senderId,
+  receiverId,
+}: ProfileLikeBody): Promise<
+  ProfileLikeResponse | ResponseError | undefined
+> => {
+  try {
+    const { data } = await instance.post<ProfileLikeResponse>(
+      "/profiles/like",
+      {
+        senderId,
+        receiverId,
+      },
     );
     return data;
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return error.response?.data;
+    }
+  }
+};
+
+export const deleteLikeProfile = async ({
+  senderId,
+  receiverId,
+}: ProfileLikeBody): Promise<ResponseError | undefined> => {
+  try {
+    await instance.delete("/profiles/like", { senderId, receiverId });
   } catch (error) {
     if (error instanceof AxiosError) {
       return error.response?.data;

--- a/app/_common/api/profile.ts
+++ b/app/_common/api/profile.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from "axios";
 
 import { ResponseData } from "../types/response";
-import { Like, Profile, ProfileLikeInfo } from "../types/profile";
+import { Creator, Like, Profile, ProfileLikeInfo } from "../types/profile";
 import { instance } from "./instance";
 
 interface ProfileCardRequest {
@@ -53,7 +53,7 @@ export const getReceiveLikeCount = async (
 };
 
 interface ProfileLikeResponse {
-  id: number;
+  id: Creator["id"];
 }
 
 export const postLikeProfile = async ({

--- a/app/_common/types/profile.ts
+++ b/app/_common/types/profile.ts
@@ -17,3 +17,8 @@ export interface Like {
   userId: number;
   likeCount: number;
 }
+
+export interface Profile {
+  response: Creator;
+  requestYn: boolean;
+}

--- a/app/_common/types/profile.ts
+++ b/app/_common/types/profile.ts
@@ -22,3 +22,8 @@ export interface Profile {
   response: Creator;
   requestYn: boolean;
 }
+
+export interface ProfileLikeInfo {
+  senderId: number;
+  receiverId: number;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import Map from "./(map)/_components/Map";
 export default function Home() {
   return (
     <Suspense>
-      <Map />;
+      <Map />
     </Suspense>
   );
 }

--- a/app/project/_components/ButtonLike.tsx
+++ b/app/project/_components/ButtonLike.tsx
@@ -1,10 +1,22 @@
 import { IconHeartFilled } from "@tabler/icons-react";
 
+import { cn } from "@/app/_common/shadcn/utils";
 import { Button } from "@/app/_common/shadcn/ui/button";
 
-function ButtonLike() {
+interface Props {
+  onClick: () => void;
+  isLiked: boolean;
+}
+
+function ButtonLike({ onClick, isLiked }: Props) {
   return (
-    <Button className="mt-0 flex items-center justify-center bg-[#F9679C] p-2 text-white">
+    <Button
+      onClick={onClick}
+      className={cn(
+        "mt-0 flex items-center justify-center bg-[#F9679C] p-2 hover:bg-[#F9679C]",
+        isLiked ? "text-secondary" : "text-white",
+      )}
+    >
       <IconHeartFilled />
     </Button>
   );

--- a/app/project/_components/ButtonLike.tsx
+++ b/app/project/_components/ButtonLike.tsx
@@ -3,12 +3,12 @@ import { IconHeartFilled } from "@tabler/icons-react";
 import { cn } from "@/app/_common/shadcn/utils";
 import { Button } from "@/app/_common/shadcn/ui/button";
 
-interface Props {
+interface ButtonLikeProps {
   onClick: () => void;
   isLiked: boolean;
 }
 
-function ButtonLike({ onClick, isLiked }: Props) {
+function ButtonLike({ onClick, isLiked }: ButtonLikeProps) {
   return (
     <Button
       onClick={onClick}

--- a/app/project/_components/ButtonLike.tsx
+++ b/app/project/_components/ButtonLike.tsx
@@ -2,7 +2,7 @@ import { IconHeartFilled } from "@tabler/icons-react";
 
 import { Button } from "@/app/_common/shadcn/ui/button";
 
-function ButtonFollow() {
+function ButtonLike() {
   return (
     <Button className="mt-0 flex items-center justify-center bg-[#F9679C] p-2 text-white">
       <IconHeartFilled />
@@ -10,4 +10,4 @@ function ButtonFollow() {
   );
 }
 
-export default ButtonFollow;
+export default ButtonLike;

--- a/app/project/_utils/formatMeetingTime.ts
+++ b/app/project/_utils/formatMeetingTime.ts
@@ -4,7 +4,7 @@ import dayjs from "dayjs";
 
 dayjs.extend(utc);
 dayjs.extend(tz);
-const timezone = "Europe/London";
+const timezone = "Asia/Seoul";
 
 const formatMeetingTime = (isoStartTime: string, isoEndTime: string) => {
   if (!isoStartTime || !isoEndTime) return "유효하지 않은 시간 입니다.";


### PR DESCRIPTION
# 📌 작업 내용
- 찔러보기 요청/삭제 api 연결
- 성공/실패 시 토스트 메시지 띄움
- `useMutation` 옵션에서 `throwOnError: false`로 지정하여 `try/catch`문을 삭제하고 `onError`에서 에러 핸들링
- 프로필 카드 받아와 찔러보기를 한 상대인지 여부 파악하여 요청한 상대면 찔러보기 버튼에 색이 차 있고, 아닌 경우에는 비어있음
- 찔러보기 버튼 UI는 추후 디자인을 바꿀 예정이기 때문에 스타일링을 주지 않았습니다.

![화면 기록 2024-03-07 오후 3 55 47](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/73841260/b0ef4e46-300b-4bb9-b2e0-c879591b8e3b)

# 🚦 특이 사항
- 로직적인 부분이나 문법, 에러 처리 등 개선할 부분을 편하게 리뷰 주시면 감사하겠습니다.

close #67