### PR TITLE
[hotfix] user 객체, developLanguages 타입 관련 문제 해결

### DIFF
--- a/app/signup/_components/ProfileCard.tsx
+++ b/app/signup/_components/ProfileCard.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import Image from "next/image";
-import { IconMoodPuzzled } from "@tabler/icons-react";
+import { IconExclamationCircle, IconMoodPuzzled } from "@tabler/icons-react";
 
 import { useAuthStore } from "@/app/_common/store/useAuthStore";
 import { cn } from "@/app/_common/shadcn/utils";
@@ -24,6 +24,14 @@ import { WANTED_JOB } from "@/app/_common/constants/wantedJob.constants";
 
 function ProfileCard() {
   const { user } = useAuthStore();
+
+  if (!user)
+    return (
+      <div className="flex gap-2 text-red-500">
+        <IconExclamationCircle />
+        <p>유저 정보를 찾을 수 없습니다.</p>
+      </div>
+    );
 
   return (
     <Card className={cn(`inset-0 left-0 top-0  border-none shadow-md`)}>
@@ -67,7 +75,7 @@ function ProfileCard() {
             </div>
 
             <div className="flex flex-wrap items-center justify-center gap-1">
-              {user.developLanguages?.map(({ language }, index) => (
+              {user.developLanguages?.map((language, index) => (
                 <Badge key={index}>{language}</Badge>
               ))}
             </div>

--- a/app/signup/_hooks/useMutationSignup.ts
+++ b/app/signup/_hooks/useMutationSignup.ts
@@ -24,7 +24,7 @@ export const useMutationSignup = (
 
       setUser({
         ...data,
-        developLanguages,
+        developLanguages: developLanguages.map(obj => obj.language),
       });
 
       queryClient.invalidateQueries({


### PR DESCRIPTION
# 📌 작업 내용
- [x] ProfileCard 컴포넌트 user 객체가 null인 경우에 대한 예외 처리
- [x] useMutationSignup 변경된 developLanguages 타입에 대응되도록 수정

# 🚦 특이 사항
- 정상적으로 빌드 완료되는 것을 확인했습니다.
![image](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/86952779/608b3d02-dd8e-4301-904d-f98e6d904187)

close #108 