### PR TITLE
[fix] 로그인 시 사용자 정보 전역 스토어 저장 로직 구현

### DIFF
--- a/app/_common/hooks/useSearchTokens.ts
+++ b/app/_common/hooks/useSearchTokens.ts
@@ -3,6 +3,10 @@
 import { useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 
+import { useQuerySignUpUser } from "@/app/signup/_hooks/useQuerySignUpUser";
+
+import { useAuthStore } from "../store/useAuthStore";
+
 const saveNewTokens = (newAccessToken: string, newRefreshToken: string) => {
   sessionStorage.setItem("accessToken", newAccessToken);
   sessionStorage.setItem("refreshToken", newRefreshToken);
@@ -16,6 +20,8 @@ const saveUpdatedTokens = (newAccessToken: string, newRefreshToken: string) => {
 export const useSearchTokens = (type: "local" | "session") => {
   const newAccessToken = useSearchParams().get("accessToken") ?? "";
   const newRefreshToken = useSearchParams().get("refreshToken") ?? "";
+  const { data } = useQuerySignUpUser(!!newAccessToken);
+  const { setUser, user } = useAuthStore();
 
   useEffect(() => {
     if (!newAccessToken || !newRefreshToken) return;
@@ -25,7 +31,8 @@ export const useSearchTokens = (type: "local" | "session") => {
     } else {
       saveUpdatedTokens(newAccessToken, newRefreshToken);
     }
-  }, [newAccessToken, newRefreshToken, type]);
+    if (data && !user) setUser(data);
+  }, [newAccessToken, newRefreshToken, type, data]);
 
   return {
     newAccessToken,

--- a/app/signup/_hooks/useQuerySignUpUser.ts
+++ b/app/signup/_hooks/useQuerySignUpUser.ts
@@ -4,10 +4,11 @@ import { getSignUpUser } from "@/app/_common/api/auth";
 
 import { SignUpUser } from "../_type/signup";
 
-export const useQuerySignUpUser = () => {
+export const useQuerySignUpUser = (hasAccessToken = true) => {
   const { data, isLoading } = useQuery<SignUpUser>({
     queryFn: getSignUpUser,
     queryKey: ["user"],
+    enabled: hasAccessToken,
   });
 
   return { data, isLoading };


### PR DESCRIPTION
# 📌 작업 내용

## 문제상황
회원가입 후 전역 스토어에 유저 정보를 저장하는 로직(`useMutationSignup.ts`)이 있는 반면,
로그인 후 메인(`Map.tsx`)으로 진입할 때는 깃허브 로그인을 통해 리다이렉션 로직만 수행되고 있습니다. 
따라서 이미 회원가입을 한 유저가 로그인을 진행하는 경우에 스토리지에 유저 정보가 저장되지 않아(스토리지가 비어있는 경우에는 유저 정보가 존재하지 않아) `useAuthStore`를 통해 `user` 객체를 참조한다면 `null` 값으로 조회되어 이 스토어를 쓰게 되는 다른 코드에 영향을 미치게 됩니다.

## 해결방법
HOC로 구현된 `WithSearchTokens.ts`는 `Map.tsx`에 진입 시 항상 실행됩니다
유저 정보를 조회하려면 `useQuerySignUpUser.ts` 훅을 써야하는데 정보를 받아오기 위해선 엑세스 토큰이 필요한 상황입니다.
`WithSearchTokens.ts` 내부에 `useSearchTokens.ts` 훅을 통해 엑세스 토큰을 가져오는 로직이 있어서 이 훅에서 가져온 엑세스 토큰을 이용해 `useQuerySignUpUser.ts` 훅을 불러내어 유저 정보를 받아오고, 저장하도록 로직을 구현해보았습니다.
엑세스 토큰이 없으면 `useQuerySignUpUser.ts`을 호출하면 안되므로 옵셔널로 파라미터를 받도록 하여 기본값은 `true`로 하여 `useQuerySignUpUser.ts` 훅을 쓰고 있는 다른 코드에는 영향을 미치지 않도록 했습니다.

아래는 현재 dev 브랜치에서 로그인을 하는 경우와 제가 작업한 브랜치에서 로그인한 경우에 스토리지에 저장되는 것을 녹화한 영상입니다.

![화면 기록 2024-03-06 오전 10 57 42](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/73841260/61ee8a53-cb10-4786-8c4a-f2ebcfacbd2c)

# 🚦 특이 사항
저 혼자 구상하여 짜본 로직이라 더 나은 방법이 있거나 고려하지 못한 부분이 있을 것 같습니다.
문제 상황을 적어놓았으니 더 좋은 방법이 있다면 공유 부탁드립니다!!

close #100 