### PR TITLE
[fix] 지도페이지 401 에러 처리

### DIFF
--- a/app/(map)/_api/useGetRank.ts
+++ b/app/(map)/_api/useGetRank.ts
@@ -3,10 +3,13 @@ import { useQuery } from "@tanstack/react-query";
 import { getRank } from "@/app/_common/api/project";
 
 const useGetRank = () => {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: ["region-rank"],
     queryFn: getRank,
+    throwOnError: false,
   });
+
+  if (isError) return { isRankLoading: false, rank: null };
 
   return {
     isRankLoading: isLoading,

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -27,11 +27,7 @@ import EmptyCardList from "./EmptyCardList";
 import CardList from "./CardList";
 
 function Map() {
-  const {
-    data: areaCode,
-    isError: isGeoError,
-    error: geoError,
-  } = useQueryGeoAreaCode();
+  const { data: areaCode } = useQueryGeoAreaCode();
   const [regionCode, setRegionCode] = useState(0);
   const previousRegion = useRef<SVGElement | null>(null);
   const [isListShow, setIsListShow] = useState(false);
@@ -56,8 +52,6 @@ function Map() {
       else if (!hasNextProject && hasNextProfile) fetchProfile();
     });
   }, [carouselApi, hasNextProject, hasNextProfile]);
-
-  if (isGeoError) toast.error(geoError?.message);
 
   useEffect(() => {
     if (!areaCode) return;

--- a/app/_common/api/project.ts
+++ b/app/_common/api/project.ts
@@ -13,7 +13,7 @@ interface RegionRank {
   densityRankByRegion: string[];
 }
 
-export const getRank = async (): Promise<RegionRank> => {
+export const getRank = async () => {
   const { data } = await instance.get<RegionRank>("/projects/density/rank");
   return data;
 };


### PR DESCRIPTION
# 📌 작업 내용
- 프로젝트 구역별 밀도 순위를 불러오는 useGetRank 훅에서 throwOnError: false 옵션을 설정해 에러인 경우 흰 화면이 뜨지 않도록 처리
- 에러를 내는 경우 데이터 반환값 추가

아래 화면 기록을 보시면 401 에러가 나도 지도가 나오는 것을 확인할 수 있습니다.

![화면 기록 2024-03-07 오후 5 11 21](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/73841260/f97a53d7-9948-4a5d-9b40-6ac8e536fd73)


# 🚦 특이 사항
- 더 나은 개선 사항이 있는지 피드백 부탁드립니다 :D

close #120 