### PR TITLE
[fix] 유저 정보가 없는 경우 지도를 클릭했을 때 화면 막히는 에러 해결

### DIFF
--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -6,6 +6,7 @@ import { EmblaCarouselType } from "embla-carousel";
 
 import useQueryGeoAreaCode from "@/app/auth-mylocation/_hooks/useQueryGeoAreaCode";
 import { usePositionStore } from "@/app/_common/store/usePositionStore";
+import { useAuthStore } from "@/app/_common/store/useAuthStore";
 import { cn } from "@/app/_common/shadcn/utils";
 import {
   Carousel,
@@ -41,6 +42,7 @@ function Map() {
     hasNextProfile,
   } = useGetCardList(regionCode);
   const [carouselApi, setCarouselApi] = useState<CarouselApi>();
+  const { getUser } = useAuthStore();
 
   useEffect(() => {
     if (!carouselApi) return;
@@ -78,11 +80,19 @@ function Map() {
       return;
     }
 
-    const map = document.querySelector("#map-wrap") as HTMLDivElement;
-    const isZoomIn = map.style.transform.includes("scale");
     const target = event.target as SVGElement | HTMLElement;
     const isRegion = target.tagName === "path";
+    if (!getUser() && isRegion) {
+      toast.info("유저 정보가 없습니다. 로그인 후 이용해주세요!", {
+        action: {
+          label: "로그인하기",
+        },
+      });
+      return;
+    }
 
+    const map = document.querySelector("#map-wrap") as HTMLDivElement;
+    const isZoomIn = map.style.transform.includes("scale");
     if (isZoomIn) {
       if (isRegion) return;
       zoomOut();

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -73,7 +73,10 @@ function Map() {
   };
 
   const handleRegionClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (!isAllowGPS()) return;
+    if (!isAllowGPS()) {
+      toast.info("서비스를 이용하려면 GPS 수집을 허용해주세요!");
+      return;
+    }
 
     const map = document.querySelector("#map-wrap") as HTMLDivElement;
     const isZoomIn = map.style.transform.includes("scale");

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -21,6 +21,8 @@ import LoadingSpinner from "@/app/_common/components/LoadingSpinner";
 
 import REGION_CODE from "@/app/_common/constants/regionCode";
 
+import { navigate } from "@/app/_common/utils/redirect";
+
 import { formatRegionName } from "../_utils/formatRegionName";
 import useGetRank from "../_api/useGetRank";
 import useGetCardList from "../_api/useGetCardList";
@@ -86,6 +88,10 @@ function Map() {
       toast.info("유저 정보가 없습니다. 로그인 후 이용해주세요!", {
         action: {
           label: "로그인하기",
+          onClick: () => navigate("/login"),
+        },
+        actionButtonStyle: {
+          backgroundColor: "#0973DC",
         },
       });
       return;

--- a/app/_common/utils/redirect.ts
+++ b/app/_common/utils/redirect.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+export async function navigate(path: string) {
+  redirect(path);
+}


### PR DESCRIPTION
# 📌 작업 내용

- 문제 상황
    - 로컬 스토리지에 유저 정보가 없는 경우 지도를 클릭하여 해당 구역의 카드 리스트를 조회했을 때 400번대 에러가 떠 화면이 막힘
- 해결 방법
    - 클릭 시 유저 정보가 없고, 클릭한 영역이 지도이면 early return을 통해 api 호출 막음
    - 토스트 메시지를 띄워 사용자가 `로그인하기` 버튼을 클릭하면 로그인 페이지로 리다이랙트 하도록 처리
        - 클라이언트 컴포넌트일 때 next에서 제공하는 `redirect`를 사용할 수 있는 유틸을 생성 ([참고 문서](https://nextjs.org/docs/app/api-reference/functions/redirect#client-component))

![화면 기록 2024-03-08 오후 12 06 48](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/73841260/b4786927-9517-46be-89e2-ad727ab76a41)

# 🚦 특이 사항
- 개선할 수 있는 부분, 로직을 추가해야 할 부분 리뷰 주시면 감사하겠습니다!!

close #125 
