### PR TITLE
[fix] 프로젝트, 프로필 카드 조회 페이지네이션 반환값 수정

### DIFF
--- a/app/(map)/_api/useGetCardList.ts
+++ b/app/(map)/_api/useGetCardList.ts
@@ -4,6 +4,10 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { getProjectCard } from "@/app/_common/api/project";
 import { getProfileCard } from "@/app/_common/api/profile";
 
+import { ResponseData } from "@/app/_common/types/response";
+import { Project } from "@/app/_common/types/project";
+import { Profile } from "@/app/_common/types/profile";
+
 import { formatRegionName } from "../_utils/formatRegionName";
 
 const useGetCardList = (regionCode: number) => {
@@ -76,15 +80,33 @@ const useGetCardList = (regionCode: number) => {
 
   if (isProfileLoading || !profileList) {
     return {
-      cardList: { projectList: projectList.pages[0].data, profileList: [] },
+      cardList: {
+        projectList: projectList.pages.reduce(
+          (list: Project[], response: ResponseData<Project>) => {
+            return list.concat(response.data);
+          },
+          [],
+        ),
+        profileList: [],
+      },
       ...defaultValue,
     };
   }
 
   return {
     cardList: {
-      projectList: projectList.pages[0].data,
-      profileList: profileList.pages[0].data,
+      projectList: projectList.pages.reduce(
+        (list: Project[], response: ResponseData<Project>) => {
+          return list.concat(response.data);
+        },
+        [],
+      ),
+      profileList: profileList.pages.reduce(
+        (list: Profile[], response: ResponseData<Profile>) => {
+          return list.concat(response.data);
+        },
+        [],
+      ),
     },
     ...defaultValue,
   };


### PR DESCRIPTION
# 📌 작업 내용
- 프로젝트, 프로필 카드 조회에서 useInfiniteQuery에서 받아오는 데이터를 파악하여 반환값을 수정했습니다.
- 아래와 같이 데이터가 반환됩니다. (프로필만 예시로 적어놓음, 프로젝트도 같은 형식)

```js
const profileList = {
    "pages": [
        {
            "data": [
                {
                    "response": {},
                    "requestYn": false
                },
                {
                    "response": {},
                    "requestYn": false
                }
            ],
            "hasNext": true,
            "numberOfElements": 3,
            "size": 2
        },
        {
            "data": [
                {
                    "response": {},
                    "requestYn": false
                },
                {
                    "response": {},
                    "requestYn": false
                }
            ],
            "hasNext": true,
            "numberOfElements": 3,
            "size": 2
        }
    ],
    "pageParams": [
        0,
        72
    ]
}

const newProfileList = profileList.pages.reduce((list, response) => {
  return list.concat(response.data)
}, [])

console.log(newProfileList)
// [
//   { response: {}, requestYn: false },
//   { response: {}, requestYn: false },
//   { response: {}, requestYn: false },
//   { response: {}, requestYn: false }
// ]
```
# 🚦 특이 사항
- 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점을 작성해주세요.

close #119 