### PR TITLE
[style] 네비게이션 하단바 컴포넌트 생성

### DIFF
--- a/app/_common/components/NavigationBottom.tsx
+++ b/app/_common/components/NavigationBottom.tsx
@@ -11,7 +11,7 @@ function NavigationBottom() {
   return (
     <Menubar
       defaultValue={pathname}
-      className="absolute bottom-8 left-2/4 z-50 -translate-x-2/4 shadow-neo-b"
+      className="fixed bottom-8 left-2/4 z-50 -translate-x-2/4 shadow-neo-b"
     >
       <MenubarMenu value="/">
         <MenubarTrigger

--- a/app/_common/components/NavigationBottom.tsx
+++ b/app/_common/components/NavigationBottom.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { navigate } from "../utils/redirect";
+import { Menubar, MenubarMenu, MenubarTrigger } from "../shadcn/ui/menubar";
+
+function NavigationBottom() {
+  return (
+    <Menubar
+      defaultValue="map"
+      className="absolute bottom-8 left-2/4 z-50 -translate-x-2/4 shadow-neo-b"
+    >
+      <MenubarMenu value="map">
+        <MenubarTrigger
+          onClick={() => navigate("/")}
+          className="inline-block min-w-20"
+        >
+          지도
+        </MenubarTrigger>
+      </MenubarMenu>
+      <MenubarMenu>
+        <MenubarTrigger
+          onClick={() => navigate("/my-page")}
+          className="inline-block min-w-20"
+        >
+          마이
+        </MenubarTrigger>
+      </MenubarMenu>
+      <MenubarMenu>
+        <MenubarTrigger
+          onClick={() => navigate("/chat")}
+          className="inline-block min-w-20"
+        >
+          채팅
+        </MenubarTrigger>
+      </MenubarMenu>
+      <MenubarMenu>
+        <MenubarTrigger
+          onClick={() => navigate("/project")}
+          className="inline-block min-w-20"
+        >
+          모각고
+        </MenubarTrigger>
+      </MenubarMenu>
+    </Menubar>
+  );
+}
+
+export default NavigationBottom;

--- a/app/_common/components/NavigationBottom.tsx
+++ b/app/_common/components/NavigationBottom.tsx
@@ -1,15 +1,19 @@
 "use client";
 
+import { usePathname } from "next/navigation";
+
 import { navigate } from "../utils/redirect";
 import { Menubar, MenubarMenu, MenubarTrigger } from "../shadcn/ui/menubar";
 
 function NavigationBottom() {
+  const pathname = usePathname();
+
   return (
     <Menubar
-      defaultValue="map"
+      defaultValue={pathname}
       className="absolute bottom-8 left-2/4 z-50 -translate-x-2/4 shadow-neo-b"
     >
-      <MenubarMenu value="map">
+      <MenubarMenu value="/">
         <MenubarTrigger
           onClick={() => navigate("/")}
           className="inline-block min-w-20"
@@ -17,7 +21,7 @@ function NavigationBottom() {
           지도
         </MenubarTrigger>
       </MenubarMenu>
-      <MenubarMenu>
+      <MenubarMenu value="/my-page">
         <MenubarTrigger
           onClick={() => navigate("/my-page")}
           className="inline-block min-w-20"
@@ -25,7 +29,7 @@ function NavigationBottom() {
           마이
         </MenubarTrigger>
       </MenubarMenu>
-      <MenubarMenu>
+      <MenubarMenu value="/chat">
         <MenubarTrigger
           onClick={() => navigate("/chat")}
           className="inline-block min-w-20"
@@ -33,7 +37,7 @@ function NavigationBottom() {
           채팅
         </MenubarTrigger>
       </MenubarMenu>
-      <MenubarMenu>
+      <MenubarMenu value="/project">
         <MenubarTrigger
           onClick={() => navigate("/project")}
           className="inline-block min-w-20"

--- a/app/_common/hoc/WithNavigation.tsx
+++ b/app/_common/hoc/WithNavigation.tsx
@@ -1,0 +1,24 @@
+/* eslint-disable react/display-name */
+/* eslint-disable react-hooks/rules-of-hooks */
+
+import NavigationBottom from "../components/NavigationBottom";
+
+function WithNavigation<P extends object>(
+  Component: React.ComponentType<P>,
+  isShowNavigation: boolean = false,
+) {
+  return function IsNavigated(props: P) {
+    if (isShowNavigation) {
+      return (
+        <>
+          <NavigationBottom />
+          <Component {...props} />
+        </>
+      );
+    }
+
+    return <Component {...props} />;
+  };
+}
+
+export default WithNavigation;


### PR DESCRIPTION
# 📌 작업 내용

- 메뉴바 shadcn 컴포넌트를 통해 하단 네비게이션 바를 생성했습니다. 위치값도 지정해두어 컴포넌트만 쓰면 됩니다.
- pathname을 통해 defaultvalue를 제어하도록 하여 현재 위치한 페이지에서 메뉴바 아이템이 하이라이팅 되게 처리했습니다.
- 아래 이미지들은 예시로 코드를 넣어 캡쳐한 것으로, PR에는 해당 예시 코드가 올라와 있지 않습니다.
    - layout에 넣기에는 네비게이션 바가 안 들어가는 부분도 있어보이고, 아직 확실한 결론이 나지 않은 것 같아 넣지 않았습니다.

<img width="250" alt="스크린샷 2024-03-15 오후 12 14 42" src="https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/73841260/cd266819-c129-4fd3-998f-fb0405349d7c">
<img width="250" alt="스크린샷 2024-03-15 오후 12 15 19" src="https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/73841260/03ae59a5-f71c-459f-9ff3-a5b99f868b28">
<img width="250" alt="스크린샷 2024-03-15 오후 12 15 40" src="https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/73841260/7e7c600a-55db-4b6f-80fc-c0059e4f20a7">

# 🚦 특이 사항

- 좋은 방법으로 구현한 것인지 궁금합니다.
- 모든 피드백 다 환영입니다. :D

close #189 