### PR TITLE
[style] 카드 컴포넌트 스타일 변경

### DIFF
--- a/app/(map)/_components/ProfileCardItem.tsx
+++ b/app/(map)/_components/ProfileCardItem.tsx
@@ -2,11 +2,11 @@
 
 import React from "react";
 import Link from "next/link";
-import Image from "next/image";
 
+import InfoPopover from "@/app/project/_components/InfoPopover";
 import ButtonLike from "@/app/project/_components/ButtonLike";
 import { useAuthStore } from "@/app/_common/store/useAuthStore";
-import { Progress } from "@/app/_common/shadcn/ui/progress";
+import { YProgress } from "@/app/_common/shadcn/ui/y-progress";
 import {
   Card,
   CardContent,
@@ -14,7 +14,13 @@ import {
   CardFooter,
   CardHeader,
 } from "@/app/_common/shadcn/ui/card";
-import { Badge as Tag } from "@/app/_common/shadcn/ui/badge";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/app/_common/shadcn/ui/avatar";
+
+import Icon from "@/app/_common/components/Icon";
 
 import { Profile } from "@/app/_common/types/profile";
 
@@ -52,59 +58,56 @@ function ProfileCardItem({ profile }: Props) {
   };
 
   return (
-    <div className="h-[550px] w-[330px] sm:w-[450px]">
+    <div className="h-[600px] w-[330px] sm:w-[450px]">
       <div className="h-full">
         <div className="relative h-full">
-          <Card className="border-none shadow-md">
+          <Card>
             <CardHeader className="px-5 pt-4">
               <CardDescription className="flex justify-end text-lg font-bold text-black">
-                <Link href={githubUrl} target="_blank">
+                <Link
+                  href={githubUrl}
+                  target="_blank"
+                  className="flex items-center text-[#A2A2A2]"
+                >
                   @{githubId}
                 </Link>
               </CardDescription>
             </CardHeader>
-            <CardContent className="flex flex-col items-center gap-10">
-              <div className="flex flex-col items-center gap-5">
-                <div className="relative overflow-hidden rounded-xl shadow-lg">
-                  <Image
-                    src={avatarUrl}
-                    alt="프로필 이미지"
-                    width={150}
-                    height={150}
-                  />
+            <CardContent className="flex flex-col items-center gap-8 px-3 py-2">
+              <div className="flex w-full flex-col gap-3">
+                <div className="flex w-full justify-between ">
+                  <div className="relative ml-2 rounded-full">
+                    <Avatar className="h-52 w-52">
+                      <AvatarImage src={avatarUrl} alt="profile" />
+                      <AvatarFallback>CN</AvatarFallback>
+                    </Avatar>
+                  </div>
+                  <div className="flex gap-2">
+                    <div className="flex h-full items-end">
+                      <Icon id="jandi" className="mb-6 h-6 w-6" />
+                    </div>
+                    <div className="flex flex-col gap-2">
+                      <YProgress value={jandiRate} background="green" />
+                      <span className="text-xs text-[#868686]">
+                        {jandiRate * 100}%
+                      </span>
+                    </div>
+                  </div>
                 </div>
-                <div className="flex flex-col items-center gap-[6px]">
+                <div className="flex flex-col items-center gap-4">
                   <div className="flex flex-col items-center gap-1 p-1">
-                    <h1 className="text-xl font-bold">{username}</h1>
+                    <h1 className="text-2xl font-bold">{username}</h1>
                     <h3 className="text-xs text-[#F76A6A]">
                       {achievementTitle}
                     </h3>
                   </div>
-                  <p className="text-[#868686]">{bio}</p>
-                  <div className="flex flex-wrap items-center justify-center gap-1">
-                    {wantedJobs.map(job => (
-                      <Tag key={job}>{job}</Tag>
-                    ))}
-                  </div>
-                  <div className="flex flex-wrap items-center justify-center gap-1">
-                    {developLanguages.map(job => (
-                      <Tag key={job}>{job}</Tag>
-                    ))}
-                  </div>
+                  <p className="w-60 overflow-hidden text-center text-sm">
+                    {bio}
+                  </p>
                 </div>
-              </div>
-              <div className="flex w-full items-center justify-center">
-                <Image
-                  src="/images/grass.png"
-                  alt="잔디력"
-                  width={50}
-                  height={50}
-                />
-                <div className="mr-10 w-40">
-                  <Progress value={jandiRate} />
-                  <span className="text-xs text-[#868686]">
-                    {jandiRate * 100}%
-                  </span>
+                <div className="flex flex-col items-center">
+                  <InfoPopover type="INTEREST" infoList={wantedJobs} />
+                  <InfoPopover type="LANG" infoList={developLanguages} />
                 </div>
               </div>
             </CardContent>

--- a/app/_common/components/ProfileCard.tsx
+++ b/app/_common/components/ProfileCard.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import Link from "next/link";
+
+import InfoPopover from "@/app/project/_components/InfoPopover";
+
+import { YProgress } from "../shadcn/ui/y-progress";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+} from "../shadcn/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "../shadcn/ui/avatar";
+import Icon from "./Icon";
+
+interface ProfileCardProps {
+  profile: Profile;
+}
+
+function ProfileCard(props: ProfileCardProps) {
+  const {
+    profile: {
+      username,
+      githubId,
+      avatarUrl,
+      githubUrl,
+      bio,
+      jandiRate,
+      achievementTitle,
+      developLanguages,
+      wantedJobs,
+    },
+  } = props;
+
+  return (
+    <Card className="h-full w-full border-none shadow-none">
+      <CardHeader>
+        <CardDescription className="flex justify-end text-lg font-bold text-black">
+          <Link href={githubUrl} target="_blank" className="text-[#a2a2a2]">
+            @{githubId}
+          </Link>
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center gap-8 px-3 py-2">
+        <div className="flex w-full flex-col gap-3">
+          <div className="flex w-full justify-between ">
+            <div className="relative ml-2 rounded-full">
+              <Avatar className="h-52 w-52">
+                <AvatarImage src={avatarUrl} alt="profile" />
+                <AvatarFallback>CN</AvatarFallback>
+              </Avatar>
+            </div>
+            <div className="flex gap-2">
+              <div className="flex h-full items-end">
+                <Icon id="jandi" className="mb-6 h-6 w-6" />
+              </div>
+              <div className="flex flex-col gap-2">
+                <YProgress value={jandiRate} background="green" />
+                <span className="text-xs text-[#868686]">
+                  {jandiRate * 100}%
+                </span>
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex flex-col items-center gap-1 p-1">
+              <h1 className="text-2xl font-bold">{username}</h1>
+              <h3 className="text-xs text-[#F76A6A]">{achievementTitle}</h3>
+            </div>
+            <p className="w-60 overflow-hidden text-center text-sm">{bio}</p>
+          </div>
+          <div className="flex flex-col items-center">
+            <InfoPopover type="INTEREST" infoList={wantedJobs} />
+            <InfoPopover type="LANG" infoList={developLanguages} />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default ProfileCard;

--- a/app/project/_components/ButtonLike.tsx
+++ b/app/project/_components/ButtonLike.tsx
@@ -1,7 +1,7 @@
-import { IconHeartFilled } from "@tabler/icons-react";
-
 import { cn } from "@/app/_common/shadcn/utils";
 import { Button } from "@/app/_common/shadcn/ui/button";
+
+import Icon from "@/app/_common/components/Icon";
 
 interface ButtonLikeProps {
   onClick: () => void;
@@ -12,12 +12,9 @@ function ButtonLike({ onClick, isLiked }: ButtonLikeProps) {
   return (
     <Button
       onClick={onClick}
-      className={cn(
-        "mt-0 flex items-center justify-center bg-[#F9679C] p-2 hover:bg-[#F9679C]",
-        isLiked ? "text-secondary" : "text-white",
-      )}
+      className={cn("w-full", isLiked ? "text-neoRed" : "text-black")}
     >
-      <IconHeartFilled />
+      <Icon id="follow-fulfill" />
     </Button>
   );
 }

--- a/app/project/_components/ButtonRequest.tsx
+++ b/app/project/_components/ButtonRequest.tsx
@@ -30,7 +30,11 @@ function ButtonRequest(props: ButtonReuqestProps) {
     }
   };
 
-  return <Button onClick={handleRequest}>요청</Button>;
+  return (
+    <Button onClick={handleRequest} className="bg-neoBlue text-white">
+      요청
+    </Button>
+  );
 }
 
 export default ButtonRequest;

--- a/app/project/_components/ButtonRotate.tsx
+++ b/app/project/_components/ButtonRotate.tsx
@@ -15,11 +15,11 @@ function ButtonRotate(props: ButtonRotateProps) {
   return (
     <Button
       variant="ghost"
-      className="mt-0 flex items-center justify-center p-2 hover:bg-[#5454543e]"
+      className="mt-0 flex items-center justify-center p-3 hover:bg-[#5454543e]"
       onClick={onRotate}
       disabled={isDisabled}
     >
-      <Icon id="rotate" className="h-4 w-4" />
+      <Icon id="rotate" className="h-5 w-5" />
     </Button>
   );
 }

--- a/app/project/_components/ButtonRotate.tsx
+++ b/app/project/_components/ButtonRotate.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { IconRotate360 } from "@tabler/icons-react";
 
 import { Button } from "@/app/_common/shadcn/ui/button";
+
+import Icon from "@/app/_common/components/Icon";
 
 interface ButtonRotateProps {
   isDisabled?: boolean;
@@ -18,7 +19,7 @@ function ButtonRotate(props: ButtonRotateProps) {
       onClick={onRotate}
       disabled={isDisabled}
     >
-      <IconRotate360 />
+      <Icon id="rotate" className="h-4 w-4" />
     </Button>
   );
 }

--- a/app/project/_components/DialogMoreInfo.tsx
+++ b/app/project/_components/DialogMoreInfo.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+} from "@/app/_common/shadcn/ui/dialog";
+import { Button } from "@/app/_common/shadcn/ui/button";
+
+import ProfileCard from "@/app/_common/components/ProfileCard";
+import Icon from "@/app/_common/components/Icon";
+
+interface DialogMoreInfoProps extends Profile {}
+
+function DialogMoreInfo(props: DialogMoreInfoProps) {
+  const profile = props;
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="ghost">
+          <Icon id="chevron-right" size={18} />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="h-[600px] w-[330px] rounded-lg p-0 sm:w-[450px]">
+        <ProfileCard profile={profile} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default DialogMoreInfo;

--- a/app/project/_components/InfoPopover.tsx
+++ b/app/project/_components/InfoPopover.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/app/_common/shadcn/ui/popover";
+import { Button } from "@/app/_common/shadcn/ui/button";
+import { Badge } from "@/app/_common/shadcn/ui/badge";
+
+import Icon from "@/app/_common/components/Icon";
+
+import { WantedJobs } from "@/app/_common/types/user";
+
+type InfoType = "LANG" | "INTEREST";
+
+interface InfoPopoverProps {
+  type: InfoType;
+  infoList: string[] | WantedJobs[];
+}
+
+function InfoPopover(props: InfoPopoverProps) {
+  const { type, infoList } = props;
+  const title = type === "LANG" ? "개발 언어" : "관심 직무";
+  const iconId = type === "LANG" ? "info-tech" : "info-job";
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" className="flex items-center gap-10">
+          <span className="text-lg">{title}</span>
+          <Icon id="chevron-right" className="h-6 w-6" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="max-w-[200px] space-y-2">
+        <header className="flex items-center gap-3 text-lg">
+          <p>{title}</p>
+          <Icon id={iconId} className="h-6 w-6" />
+        </header>
+        <main className="flex flex-wrap gap-1">
+          {infoList.map(info => (
+            <Badge key={info} variant="outline">
+              {info}
+            </Badge>
+          ))}
+        </main>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export default InfoPopover;

--- a/app/project/_components/ProjectCardBack.tsx
+++ b/app/project/_components/ProjectCardBack.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { forwardRef } from "react";
-import Image from "next/image";
 
 import { Separator } from "@/app/_common/shadcn/ui/separator";
 import {
@@ -11,10 +10,15 @@ import {
   CardTitle,
 } from "@/app/_common/shadcn/ui/card";
 import { Button } from "@/app/_common/shadcn/ui/button";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/app/_common/shadcn/ui/avatar";
 
 import useAcceptRequestMutation from "../_hooks/useAcceptRequestMutation";
+import DialogMoreInfo from "./DialogMoreInfo";
 import ButtonRotate from "./ButtonRotate";
-import BadgeAdditional from "./BadgeAdditional";
 import "../_styles/card.css";
 
 interface CardBackProps {
@@ -56,7 +60,11 @@ const ProjectCardBack = forwardRef<HTMLDivElement, CardBackProps>(
                     senderPreview: {
                       id: senderId,
                       username,
+                      githubId,
                       avatarUrl,
+                      githubUrl,
+                      bio,
+                      jandiRate,
                       achievementTitle,
                       developLanguages,
                       wantedJobs,
@@ -70,33 +78,35 @@ const ProjectCardBack = forwardRef<HTMLDivElement, CardBackProps>(
                         key={senderId}
                         className="flex items-center justify-between"
                       >
-                        <aside className="flex items-center gap-3">
-                          <Image
-                            src={avatarUrl}
-                            alt="프로필 이미지"
-                            width={60}
-                            height={60}
-                            className="rounded-2xl"
-                          />
-                          <div className="flex flex-col gap-3">
-                            <div className="flex items-center gap-2">
-                              <p className="text-lg font-semibold">
-                                {username}
-                              </p>
-                              <p className="text-xs text-[#F76A6A]">
-                                {achievementTitle || "null"}
-                              </p>
-                            </div>
+                        <aside className="flex items-center gap-5">
+                          <div className="ml-2 rounded-full">
+                            <Avatar className="h-14 w-14">
+                              <AvatarImage src={avatarUrl} alt="profile" />
+                              <AvatarFallback>CN</AvatarFallback>
+                            </Avatar>
+                          </div>
+                          <div className="flex flex-col gap-2">
+                            <p className="text-lg font-semibold">{username}</p>
+                            <p className="text-xs text-[#F76A6A]">
+                              {achievementTitle || "null"}
+                            </p>
                           </div>
                         </aside>
                         <aside className="flex items-center gap-2">
-                          <BadgeAdditional
-                            wantedJobs={wantedJobs}
+                          <DialogMoreInfo
+                            githubId={githubId}
+                            githubUrl={githubUrl}
+                            username={username}
+                            avatarUrl={avatarUrl}
+                            bio={bio}
+                            jandiRate={jandiRate}
+                            achievementTitle={achievementTitle}
                             developLanguages={developLanguages}
+                            wantedJobs={wantedJobs}
                           />
                           <Button
                             size="sm"
-                            className="rounded-lg"
+                            className="rounded-lg bg-neoYellow"
                             onClick={() => handleAccept(id)}
                           >
                             수락

--- a/app/project/_components/ProjectCardContainer.tsx
+++ b/app/project/_components/ProjectCardContainer.tsx
@@ -43,8 +43,8 @@ function ProjectCardContainer({ project }: Props) {
   }, [data]);
 
   return (
-    <Tabs defaultValue="card" className="h-[550px] w-[330px] sm:w-[450px]">
-      <TabsList className="glass-morphism grid w-full grid-cols-2">
+    <Tabs defaultValue="card" className="h-[600px] w-[330px] sm:w-[450px]">
+      <TabsList className="grid w-full grid-cols-2">
         <TabsTrigger value="card">Card</TabsTrigger>
         <TabsTrigger value="chat">Chat</TabsTrigger>
       </TabsList>

--- a/app/project/_components/ProjectCardFront.tsx
+++ b/app/project/_components/ProjectCardFront.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import React from "react";
-import Image from "next/image";
-import { IconMoodPuzzled } from "@tabler/icons-react";
 
 import { useAuthStore } from "@/app/_common/store/useAuthStore";
 import { cn } from "@/app/_common/shadcn/utils";
-import { Progress } from "@/app/_common/shadcn/ui/progress";
+import { YProgress } from "@/app/_common/shadcn/ui/y-progress";
 import {
   Popover,
   PopoverContent,
@@ -19,14 +17,23 @@ import {
   CardFooter,
   CardHeader,
 } from "@/app/_common/shadcn/ui/card";
-import { Badge as Tag } from "@/app/_common/shadcn/ui/badge";
+import { Badge } from "@/app/_common/shadcn/ui/badge";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/app/_common/shadcn/ui/avatar";
+
+import Icon from "@/app/_common/components/Icon";
 
 import { Project } from "@/app/_common/types/project";
 
 import formatMeetingTime from "../_utils/formatMeetingTime";
 import ProjectRemoveDialog from "./ProjectRemoveDialog";
+import InfoPopover from "./InfoPopover";
 import ButtonRotate from "./ButtonRotate";
 import ButtonRequest from "./ButtonRequest";
+
 import "../_styles/card.css";
 
 interface CardFrontProps {
@@ -36,8 +43,6 @@ interface CardFrontProps {
 }
 
 function ProjectCardFront(props: CardFrontProps) {
-  // TODO: 요청이 있을 경우 삭제하지 못하는 로직 추가하기
-  // TODO: 사용자(제안자, 요청자)타입에 따라 Footer의 버튼 조건부 렌더링 추가하기(매칭 취소, 카드 취소, 요청)
   const {
     initialRotate,
     onRotate,
@@ -51,6 +56,7 @@ function ProjectCardFront(props: CardFrontProps) {
         bio,
         wantedJobs,
         jandiRate,
+        developLanguages,
       },
       projectTags,
       projectId,
@@ -66,7 +72,7 @@ function ProjectCardFront(props: CardFrontProps) {
         initialRotate ? "[transform:rotateY(180deg)]" : "",
       )}
     >
-      <CardHeader className="px-5 pt-4">
+      <CardHeader className="px-3 pt-2">
         <CardDescription className="flex justify-between text-lg font-bold text-black">
           <span className="flex items-center">
             <ButtonRotate
@@ -75,55 +81,64 @@ function ProjectCardFront(props: CardFrontProps) {
             />
             <Popover>
               <PopoverTrigger className="rounded-md p-2 hover:bg-[#5454543e]">
-                <IconMoodPuzzled />
+                <Icon id="project-tag" className="h-5 w-5" />
               </PopoverTrigger>
-              <PopoverContent className="max-w-[130px]">
-                <h1 className="mb-2 text-sm font-bold">🏷️ 분위기 태그</h1>
-                {projectTags.map(tag => (
-                  <Tag key={tag}>{tag}</Tag>
-                ))}
+              <PopoverContent className="max-w-[150px]">
+                <h1 className="mb-2 text-base font-bold">분위기 태그</h1>
+                <div className="flex flex-wrap gap-1">
+                  {projectTags.map(tag => (
+                    <Badge key={tag} variant="outline">
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
               </PopoverContent>
             </Popover>
           </span>
-          <span className="flex items-center">@{githubId}</span>
+          <span className="flex items-center text-[#A2A2A2]">@{githubId}</span>
         </CardDescription>
       </CardHeader>
-      <CardContent className="flex flex-col items-center gap-10">
-        <div className="flex flex-col items-center gap-5">
-          <div className="relative overflow-hidden rounded-xl shadow-lg">
-            <Image
-              src={avatarUrl}
-              alt="프로필 이미지"
-              width={150}
-              height={150}
-            />
+      <CardContent className="flex flex-col items-center gap-8 px-3">
+        <div className="flex w-full flex-col gap-3">
+          <div className="flex w-full justify-between ">
+            <div className="relative ml-2 rounded-full">
+              <Avatar className="h-52 w-52">
+                <AvatarImage src={avatarUrl} alt="profile" />
+                <AvatarFallback>CN</AvatarFallback>
+              </Avatar>
+            </div>
+            <div className="flex gap-2">
+              <div className="flex h-full items-end">
+                <Icon id="jandi" className="mb-6 h-6 w-6" />
+              </div>
+              <div className="flex flex-col gap-2">
+                <YProgress value={jandiRate} background="green" />
+                <span className="text-xs text-[#868686]">
+                  {jandiRate * 100}%
+                </span>
+              </div>
+            </div>
           </div>
-          <div className="flex flex-col items-center gap-[6px]">
+          <div className="flex flex-col items-center gap-4">
             <div className="flex flex-col items-center gap-1 p-1">
-              <h1 className="text-xl font-bold">{username}</h1>
+              <h1 className="text-2xl font-bold">{username}</h1>
               <h3 className="text-xs text-[#F76A6A]">{achievementTitle}</h3>
             </div>
-            <p className="text-[#868686]">{bio}</p>
-            <div className="flex flex-wrap items-center justify-center gap-1">
-              {wantedJobs.map(job => (
-                <Tag key={job}>{job}</Tag>
-              ))}
-            </div>
+            <p className="w-60 overflow-hidden text-center text-sm">{bio}</p>
           </div>
-        </div>
-        <div className="flex w-full items-center justify-center">
-          <Image src="/images/grass.png" alt="잔디력" width={50} height={50} />
-          <div className="mr-10 w-40">
-            <Progress value={jandiRate} />
-            <span className="text-xs text-[#868686]">{jandiRate * 100}%</span>
+          <div className="flex flex-col items-center">
+            <InfoPopover type="INTEREST" infoList={wantedJobs} />
+            <InfoPopover type="LANG" infoList={developLanguages} />
           </div>
         </div>
       </CardContent>
       {!initialRotate && (
         <CardFooter className="flex items-center justify-between">
           <div>
-            <p className="font-bold">📍 {meetDetail}</p>
-            <p>🕡 {formatMeetingTime(meetStartTime, meetEndTime)}</p>
+            <p className="font-bold">{meetDetail}</p>
+            <p className="text-xs">
+              {formatMeetingTime(meetStartTime, meetEndTime)}
+            </p>
           </div>
           {user && user.id !== id ? (
             <ButtonRequest projectId={projectId} />

--- a/app/project/_components/ProjectCardFront.tsx
+++ b/app/project/_components/ProjectCardFront.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import Link from "next/link";
 
 import { useAuthStore } from "@/app/_common/store/useAuthStore";
 import { cn } from "@/app/_common/shadcn/utils";
@@ -51,6 +52,7 @@ function ProjectCardFront(props: CardFrontProps) {
         id,
         githubId,
         avatarUrl,
+        githubUrl,
         username,
         achievementTitle,
         bio,
@@ -80,7 +82,7 @@ function ProjectCardFront(props: CardFrontProps) {
               onRotate={onRotate}
             />
             <Popover>
-              <PopoverTrigger className="rounded-md p-2 hover:bg-[#5454543e]">
+              <PopoverTrigger className="rounded-md p-3 hover:bg-[#5454543e]">
                 <Icon id="project-tag" className="h-5 w-5" />
               </PopoverTrigger>
               <PopoverContent className="max-w-[150px]">
@@ -95,10 +97,16 @@ function ProjectCardFront(props: CardFrontProps) {
               </PopoverContent>
             </Popover>
           </span>
-          <span className="flex items-center text-[#A2A2A2]">@{githubId}</span>
+          <Link
+            href={githubUrl}
+            target="_blank"
+            className="flex items-center text-[#A2A2A2]"
+          >
+            @{githubId}
+          </Link>
         </CardDescription>
       </CardHeader>
-      <CardContent className="flex flex-col items-center gap-8 px-3">
+      <CardContent className="flex flex-col items-center gap-8 px-3 py-2">
         <div className="flex w-full flex-col gap-3">
           <div className="flex w-full justify-between ">
             <div className="relative ml-2 rounded-full">
@@ -133,7 +141,7 @@ function ProjectCardFront(props: CardFrontProps) {
         </div>
       </CardContent>
       {!initialRotate && (
-        <CardFooter className="flex items-center justify-between">
+        <CardFooter className="flex items-center justify-between px-4">
           <div>
             <p className="font-bold">{meetDetail}</p>
             <p className="text-xs">

--- a/app/project/_components/ProjectChatCard.tsx
+++ b/app/project/_components/ProjectChatCard.tsx
@@ -22,7 +22,7 @@ function ProjectChatCard(props: ChatCardProps) {
   const { messages } = props;
 
   return (
-    <Card className="glass-morphism overflow-hidden border-none shadow-md">
+    <Card className="overflow-hidden">
       <CardHeader className="border-b border-black py-4">
         <CardTitle className="text-base">📍 맥심플랜트 이태원점</CardTitle>
       </CardHeader>

--- a/app/project/_components/ProjectRemoveDialog.tsx
+++ b/app/project/_components/ProjectRemoveDialog.tsx
@@ -44,9 +44,8 @@ function ProjectRemoveDialog(props: ProjectRemoveDialogProps) {
   const titleComponent = isMatchedProject
     ? "정말 매칭을 취소하시겠어요?"
     : "정말 프로젝트를 취소하시겠어요?";
-  const descriptionComponent = isMatchedProject
-    ? "한 번 취소된 매칭은 되돌릴 수 없어요!"
-    : "한 번 취소된 프로젝트는 되돌릴 수 없어요!";
+
+  const descriptionComponent = "이 작업은 되돌릴 수 없어요!";
 
   const handleCancelProject = async () => {
     createCancelProject();
@@ -65,18 +64,22 @@ function ProjectRemoveDialog(props: ProjectRemoveDialogProps) {
       <AlertDialogOverlay className="h-full w-full bg-transparent backdrop-blur-md" />
       <AlertDialogContent className="flex max-w-[300px] flex-col items-start gap-10 rounded-lg border border-black shadow-neo">
         <AlertDialogHeader>
-          <AlertDialogTitle>{titleComponent}</AlertDialogTitle>
-          <AlertDialogDescription>
+          <AlertDialogTitle className="text-base">
+            {titleComponent}
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-xs">
             {descriptionComponent}
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <AlertDialogFooter className="flex flex-row items-center gap-2 self-end">
+        <AlertDialogFooter className="flex w-full flex-col gap-2 sm:flex-col">
           <AlertDialogAction
             onClick={isMatchedProject ? handleCancelMatch : handleCancelProject}
           >
-            진행
+            취소할래요.
           </AlertDialogAction>
-          <AlertDialogCancel className="mt-0">취소</AlertDialogCancel>
+          <AlertDialogCancel className="ml-0 mt-0 sm:ml-0">
+            안 할래요.
+          </AlertDialogCancel>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/app/project/_components/ProjectRemoveDialog.tsx
+++ b/app/project/_components/ProjectRemoveDialog.tsx
@@ -58,10 +58,12 @@ function ProjectRemoveDialog(props: ProjectRemoveDialogProps) {
 
   return (
     <AlertDialog>
-      <AlertDialogTrigger asChild>{triggerComponent}</AlertDialogTrigger>
+      <AlertDialogTrigger asChild className="bg-neoRed text-white">
+        {triggerComponent}
+      </AlertDialogTrigger>
       <AlertDialogPortal />
       <AlertDialogOverlay className="h-full w-full bg-transparent backdrop-blur-md" />
-      <AlertDialogContent className="flex max-w-[300px] flex-col items-start gap-10 rounded-lg">
+      <AlertDialogContent className="flex max-w-[300px] flex-col items-start gap-10 rounded-lg border border-black shadow-neo">
         <AlertDialogHeader>
           <AlertDialogTitle>{titleComponent}</AlertDialogTitle>
           <AlertDialogDescription>

--- a/app/project/_types/type.d.ts
+++ b/app/project/_types/type.d.ts
@@ -30,20 +30,22 @@ interface PlaceResponseProps {
   documents: PlaceItem[];
 }
 
+interface Profile {
+  id?: number;
+  username: string;
+  githubId: string;
+  avatarUrl: string;
+  githubUrl: string;
+  bio: string;
+  jandiRate: number;
+  achievementTitle: string;
+  developLanguages: string[];
+  wantedJobs: string[];
+}
+
 interface RequestList {
   id: number;
-  senderPreview: {
-    id: number;
-    username: string;
-    githubId: string;
-    avatarUrl: string;
-    githubUrl: string;
-    bio: string;
-    jandiRate: number;
-    achievementTitle: string;
-    developLanguages: string[];
-    wantedJobs: string[];
-  };
+  senderPreview: Profile;
   requestStatus: string;
 }
 


### PR DESCRIPTION
# 📌 작업 내용
- [x] 프로젝트 카드 컴포넌트 스타일 변경
- [x] 프로필 카드 컴포넌트 스타일 변경

|프로필 카드 1|프로필 카드 2|
|--|--|
|![스크린샷 2024-03-17 18 55 36](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/101445377/7451227f-54a6-46b7-9daa-1ef1dde79a10)|![스크린샷 2024-03-17 18 55 31](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/101445377/bc3d54f3-f7f7-4ee8-8f47-7e316fa022aa)|


|프로젝트 카드 앞면|프로젝트 카드 뒷면|채팅 카드|
|--|--|--|
|![스크린샷 2024-03-17 18 55 49](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/101445377/2f265937-198b-406e-bb6c-7481bd869d89)|![스크린샷 2024-03-17 18 55 57](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/101445377/bcb5ea2b-a668-4b5b-ac23-5166eebf5541)|![스크린샷 2024-03-17 18 57 06](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/101445377/5b2c7d63-7c23-4cf5-8807-9501e53a1375)|

# 🚦 특이 사항
- 기존에 존재하는 `ProfileCardItem`은, `requestYn` 데이터를 필요로 하는데 프로젝트 카드에서 사용하는 프로필 카드의 경우 해당 데이터를 따로 API에서 불러올 수 없기 때문에, 임시로 `ProfileCard`라는 컴포넌트를 새로 생성하여 사용했습니다.
  - 추후 리팩토링 사항에 추가하겠습니다.
- 채팅 카드는 채팅 페이지에서 사용하는 컴포넌트를 사용해야 하는데 아직 적용하지 못해서, 스타일이 약간 다릅니다. 빠르게 적용하겠습니다.

close #199 