### PR TITLE
[style] sonner toast 스타일, 위치 수정

### DIFF
--- a/app/_common/components/CustomSonner.tsx
+++ b/app/_common/components/CustomSonner.tsx
@@ -30,12 +30,12 @@ function CustomSonner(props: CustomSonnerProps) {
       <div className="flex items-center justify-start">
         <Icon id={`toast-${type}`} size={25} />
         <div className="px-4">
-          <h5 className="">{title}</h5>
-          {description && <h6>{description}</h6>}
+          <h5 className="text-sm">{title}</h5>
+          {description && <h6 className="text-xs">{description}</h6>}
         </div>
       </div>
       {label && onClick && (
-        <Button className="text-black" onClick={onClick}>
+        <Button className="text-xs text-black" onClick={onClick}>
           {label}
         </Button>
       )}

--- a/app/_common/utils/toast.tsx
+++ b/app/_common/utils/toast.tsx
@@ -21,7 +21,6 @@ export const toast = {
         label={data?.action?.label}
         onClick={data?.action?.onClick}
       />,
-      { unstyled: true },
     );
   },
   error(title: string, data?: SonnerData) {
@@ -33,7 +32,6 @@ export const toast = {
         label={data?.action?.label}
         onClick={data?.action?.onClick}
       />,
-      { unstyled: true },
     );
   },
   warning(title: string, data?: SonnerData) {
@@ -45,7 +43,6 @@ export const toast = {
         label={data?.action?.label}
         onClick={data?.action?.onClick}
       />,
-      { unstyled: true },
     );
   },
   info(title: string, data?: SonnerData) {
@@ -57,7 +54,6 @@ export const toast = {
         label={data?.action?.label}
         onClick={data?.action?.onClick}
       />,
-      { unstyled: true },
     );
   },
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,6 +40,9 @@ export default function RootLayout({
             <SVGProvider />
             <Sonner
               position="top-center"
+              toastOptions={{
+                style: { background: "transparent" },
+              }}
             />
           </ThemeProvider>
         </ClientProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,7 +38,9 @@ export default function RootLayout({
             {children}
             <Toaster />
             <SVGProvider />
-            <Sonner position="bottom-center" />
+            <Sonner
+              position="top-center"
+            />
           </ThemeProvider>
         </ClientProvider>
         <Toaster />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -42,6 +42,7 @@ export default function RootLayout({
               position="top-center"
               toastOptions={{
                 style: { background: "transparent" },
+                unstyled: true,
               }}
             />
           </ThemeProvider>


### PR DESCRIPTION
# 📌 작업 내용
- 글씨 크기 줄이기
- 상단에 토스트가 뜨도록 변경
- 배경색에 하얀색 노출 되는 부분 수정

<img width="387" alt="스크린샷 2024-03-18 오후 9 51 07" src="https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/73841260/e25092f2-26be-4552-a6a8-7958212d68a5">

# 🚦 특이 사항
- 리팩토링 할 부분 공유 주시면 감사하겠습니다!

close #214 