### PR TITLE
[fix] 캐러샐 카드 닫을 때 끊기며 사라지는 버그 해결

### DIFF
--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -134,8 +134,8 @@ function Map() {
       </div>
       <Carousel
         className={cn(
-          "z-60 h-screen w-screen transition-all delay-1000 duration-300",
-          isListShow ? "visible opacity-100" : "invisible opacity-0",
+          "z-60 h-screen w-screen transition-all delay-0 duration-300",
+          isListShow ? "visible opacity-100 delay-1000" : "invisible opacity-0",
         )}
         setApi={setCarouselApi}
       >

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -134,7 +134,7 @@ function Map() {
       </div>
       <Carousel
         className={cn(
-          "z-60 h-screen w-screen transition-opacity delay-1000 duration-300",
+          "z-60 h-screen w-screen transition-all delay-1000 duration-300",
           isListShow ? "visible opacity-100" : "invisible opacity-0",
         )}
         setApi={setCarouselApi}
@@ -144,7 +144,7 @@ function Map() {
           className="flex h-full w-full flex-col items-center justify-center"
         >
           {cardList.projectList.length !== 0 ||
-          cardList.profileList.length !== 0 ? (
+            cardList.profileList.length !== 0 ? (
             <CardList cardList={cardList} onClick={handleCardClose} />
           ) : (
             <EmptyCardList onClick={handleCardClose} />


### PR DESCRIPTION
# 📌 작업 내용

transition 범위가 opacity 한정으로 visibility 속성이 transition 처리가 되지 않아 끊기며 카드가 닫히는 현상이 발생했습니다.
따라서 transition-all 클래스를 지정하여 범위를 all로 넓혔습니다.

또한 지도 확대(1초) > 카드 나타남 로직으로 카드가 나타날 떄(확대될 때)는 애니메이션 딜레이를 1초 두고, 카드가 사라지는 경우에는 딜레이를 두지 않았습니다.

![화면 기록 2024-03-18 오후 10 08 40](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/73841260/7c9b7bc8-d0f3-4fee-8d1b-38e1e08b7ca2)

# 🚦 특이 사항
- 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점을 작성해주세요.

close #222 