### PR TITLE
[feat] 업적 리스트 정렬 기능 추가

### DIFF
--- a/app/achievements/_components/AchievementList.tsx
+++ b/app/achievements/_components/AchievementList.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { AspectRatio } from "@radix-ui/react-aspect-ratio";
+
+import WithOnMounted from "@/app/_common/hoc/withOnMounted";
 
 import LoadingSpinner from "@/app/_common/components/LoadingSpinner";
 import Icon from "@/app/_common/components/Icon";
+
+import { Achievement } from "@/app/_common/types/user";
 
 import { toast } from "@/app/_common/utils/toast";
 
@@ -14,10 +19,15 @@ import AchievementItem from "./AchievementItem";
 
 function AchievementList() {
   const { achievements, myAchievement } = useQueryAchievements();
+  const [sorting, setSorting] = useState<Achievement[]>([]);
 
   const handleClickMyAchievement = () => {
     toast.info("아직 설정된 업적이 없어요.");
   };
+
+  useEffect(() => {
+    setSorting(achievements);
+  }, [achievements]);
 
   if (!achievements) return <LoadingSpinner />;
 
@@ -55,10 +65,10 @@ function AchievementList() {
         )}
       </header>
       <section className="flex justify-end text-start">
-        <ListSortSelect />
+        <ListSortSelect setSorting={setSorting} achievements={achievements} />
       </section>
       <ul className="mt-3 grid w-full grid-cols-1 gap-4">
-        {achievements?.map((achievement, index) => (
+        {sorting?.map((achievement, index) => (
           <AchievementItem
             styleType="item"
             achievement={achievement}
@@ -73,4 +83,4 @@ function AchievementList() {
   );
 }
 
-export default AchievementList;
+export default WithOnMounted(AchievementList);

--- a/app/achievements/_components/ListSortSelect.tsx
+++ b/app/achievements/_components/ListSortSelect.tsx
@@ -1,29 +1,89 @@
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/app/_common/shadcn/ui/select";
+import { Dispatch, SetStateAction, useState } from "react";
 
-function ListSortSelect() {
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  DropdownMenuCheckboxItem,
+} from "@/app/_common/shadcn/ui/dropdown-menu";
+import { Button } from "@/app/_common/shadcn/ui/button";
+
+import { Achievement } from "@/app/_common/types/user";
+
+interface ListSortSelectProps {
+  achievements: Achievement[];
+  setSorting: Dispatch<SetStateAction<Achievement[]>>;
+}
+
+function ListSortSelect({ setSorting, achievements }: ListSortSelectProps) {
+  const [sortChecked, setSortChecked] = useState({
+    words: true,
+    completed: false,
+    progress: false,
+  });
+
+  const handleSetSortByWords = () => {
+    const sortedAchievements = [...achievements].sort((a, b) =>
+      a.title.localeCompare(b.title),
+    );
+    setSorting(sortedAchievements);
+
+    setSortChecked({ words: true, completed: false, progress: false });
+  };
+
+  const handleSetSortByMoreLeft = () => {
+    const sortedAchievements = [...achievements].sort(
+      (a, b) =>
+        a.requirementValue -
+        a.progressCount -
+        (b.requirementValue - b.progressCount),
+    );
+    setSorting(sortedAchievements);
+
+    setSortChecked({ words: false, completed: true, progress: false });
+  };
+
+  const handleSetSortByLessLeft = () => {
+    const sortedAchievements = [...achievements].sort(
+      (a, b) =>
+        b.requirementValue -
+        b.progressCount -
+        (a.requirementValue - a.progressCount),
+    );
+    setSorting(sortedAchievements);
+
+    setSortChecked({ words: false, completed: false, progress: true });
+  };
+
   return (
-    <Select>
-      <SelectTrigger className="w-30 translate-x-0 translate-y-0 border-none px-2 shadow-none">
-        <SelectValue placeholder="정렬" />
-      </SelectTrigger>
-      <SelectContent className="min-w-[6rem] text-end">
-        <SelectItem className="pr-0" value="light" defaultChecked>
+    <DropdownMenu>
+      <DropdownMenuTrigger className="w-30 translate-x-0 translate-y-0 border-none px-2 pr-1 shadow-none">
+        <Button className="text-sm" variant={"ghost"}>
+          정렬
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[6rem]">
+        <DropdownMenuCheckboxItem
+          onSelect={handleSetSortByWords}
+          defaultChecked
+          checked={sortChecked.words}
+        >
           글자순
-        </SelectItem>
-        <SelectItem className="pr-0" value="dark">
-          완료순
-        </SelectItem>
-        <SelectItem className="pr-0" value="system">
-          달성순
-        </SelectItem>
-      </SelectContent>
-    </Select>
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          onSelect={handleSetSortByMoreLeft}
+          checked={sortChecked.completed}
+        >
+          달성 높은 순
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          onSelect={handleSetSortByLessLeft}
+          checked={sortChecked.progress}
+        >
+          달성 적은 순
+        </DropdownMenuCheckboxItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 


### PR DESCRIPTION
# 📌 작업 내용
- 구현 내용 및 작업 했던 내역, 사진필요한 경우 선택적으로 첨부해주세요.
- [x] 업적 리스트를 글자순, 달성 높은 순, 달성 낮은 순으로 정렬할 수 있는 기능을 추가했습니다.
- [ ] 로그인 서버 api 변경으로 인하여 로그인이 되지 않아 예시 gif를 넣지 못했습니다. #227 merge 후 추가하겠습니다.

# 🚦 특이 사항
- 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점을 작성해주세요.
close #205 
