### PR TITLE
[refactor] WebSocket 구현 방식 리팩토링

### DIFF
--- a/app/_common/hooks/useChat.ts
+++ b/app/_common/hooks/useChat.ts
@@ -35,6 +35,7 @@ function useChat({ url, chatRoomId, userId }: useChatProps) {
     client.current.onConnect = () => {
       client.current?.subscribe(`/topic/chatroom/${chatRoomId}`, data => {
         const { id, message, senderId, createdAt } = JSON.parse(data.body);
+        if (userId === senderId) return;
         addNewMessage([
           {
             id,

--- a/app/_common/hooks/useChat.ts
+++ b/app/_common/hooks/useChat.ts
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState } from "react";
+import dayjs from "dayjs";
+import { Client } from "@stomp/stompjs";
+
+import { useGetPrevMessageList } from "@/app/chat/[id]/_hooks/useGetPrevMessageList";
+
+interface useChatProps {
+  url: string;
+  chatRoomId: string;
+  userId: number;
+}
+
+function useChat({ url, chatRoomId, userId }: useChatProps) {
+  const client = useRef<Client | null>(null);
+  const {
+    data: prevChatMessageList,
+    isFetchedAfterMount,
+    isLoading,
+  } = useGetPrevMessageList(chatRoomId);
+
+  const [messageList, setMessageList] = useState<CustomMessageType[]>([]);
+  const [currentSender, setCurrentSender] = useState(userId);
+
+  const connect = () => {
+    const currentUserAccessToken = localStorage.getItem("accessToken");
+
+    client.current = new Client({
+      brokerURL: url,
+      connectHeaders: {
+        Authorization: `Bearer ${currentUserAccessToken}`,
+      },
+      reconnectDelay: 10000,
+    });
+
+    client.current.onConnect = () => {
+      client.current?.subscribe(`/topic/chatroom/${chatRoomId}`, data => {
+        const { id, message, senderId, createdAt } = JSON.parse(data.body);
+        addNewMessage([
+          {
+            id,
+            message,
+            senderId,
+            createdAt,
+          },
+        ]);
+      });
+    };
+
+    client.current.onWebSocketError = e => {
+      console.error(e);
+    };
+
+    client.current.activate();
+  };
+
+  const disconnect = () => {
+    client.current?.deactivate();
+  };
+
+  const publishSocketMessage = (userId: number, message: string) => {
+    client.current?.publish({
+      destination: `/app/chatroom/${chatRoomId}`,
+      body: JSON.stringify({
+        messageType: "TALK",
+        userId: userId,
+        message,
+      }),
+    });
+  };
+
+  const checkOption = (newList: CustomMessageType[], message: MessageType) => {
+    const prevTime = newList[newList.length - 1]?.createdAt;
+    const prevSender = newList[newList.length - 1]?.senderId;
+    return !(
+      message.senderId === prevSender &&
+      dayjs(message.createdAt).isSame(dayjs(prevTime), "minute")
+    );
+  };
+
+  const addNewMessage = (newMessages: MessageType[]) => {
+    newMessages.forEach((message: MessageType) => {
+      return setMessageList(prev => {
+        setCurrentSender(message.senderId);
+        if (prev.length === 0) return [{ ...message, isTime: true }];
+        return filterCustomMessages([...prev], message);
+      });
+    });
+  };
+
+  const filterCustomMessages = (
+    newList: CustomMessageType[],
+    message: MessageType,
+  ) => {
+    const isTime = checkOption(newList, message);
+    const prevMessage = { ...newList[newList.length - 1], isTime: isTime };
+    const newMessage = { ...message, isTime: true };
+
+    newList.pop();
+    newList.push(prevMessage);
+    newList.push(newMessage);
+    return newList;
+  };
+
+  useEffect(() => {
+    connect();
+
+    return () => {
+      disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isFetchedAfterMount) {
+      addNewMessage(prevChatMessageList!);
+    }
+  }, [isFetchedAfterMount, prevChatMessageList]);
+
+  return {
+    clientRef: client,
+    publishSocketMessage,
+    addNewMessage,
+    messageList,
+    currentSender,
+    isLoadMessage: isLoading,
+  };
+}
+
+export default useChat;

--- a/app/chat/[id]/_components/MessageContainer.tsx
+++ b/app/chat/[id]/_components/MessageContainer.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { Client } from "@stomp/stompjs";
+import { useEffect, useState } from "react";
 
 import { useAuthStore } from "@/app/_common/store/useAuthStore";
 
+import useChat from "@/app/_common/hooks/useChat";
+
 import { useScroll } from "../_hooks/useScroll";
-import { useGetPrevMessageList } from "../_hooks/useGetPrevMessageList";
-import { useCustomMessage } from "../_hooks/useCustomMessage";
 import UpScrollButton from "./UpScrollButton";
 import MessageInput from "./MessageInput";
 import Message from "./Message";
@@ -19,56 +18,23 @@ interface MessageContainerProps {
 // TODO: props로 받은 chatMessageList를 useCustomMessage에 넘겨서 필터링 처리
 function MessageContainer(props: MessageContainerProps) {
   const { chatRoomId } = props;
-  const {
-    data: prevChatMessageList,
-    isFetchedAfterMount,
-    isLoading,
-  } = useGetPrevMessageList(chatRoomId);
-  const client = useRef<Client | null>(null);
   const { user } = useAuthStore();
-  const { messageList, addNewMessage, currentSender } = useCustomMessage(
-    user!.id,
-  );
+  const {
+    clientRef,
+    publishSocketMessage,
+    addNewMessage,
+    messageList,
+    currentSender,
+    isLoadMessage,
+  } = useChat({
+    url: "ws://3.38.76.76:8080/chat",
+    chatRoomId,
+    userId: user!.id,
+  });
 
   const { scrollRef, handleScroll, scrollToBottom, isScrollUpper } =
     useScroll();
   const [exposureMessage, setExposureMessage] = useState("");
-
-  const connect = () => {
-    const currentUserAccessToken = localStorage.getItem("accessToken");
-
-    client.current = new Client({
-      brokerURL: "ws://3.38.76.76:8080/chat",
-      connectHeaders: {
-        Authorization: `Bearer ${currentUserAccessToken}`,
-      },
-      reconnectDelay: 10000,
-    });
-
-    client.current.onConnect = () => {
-      client.current?.subscribe(`/topic/chatroom/${chatRoomId}`, data => {
-        const { id, message, senderId, createdAt } = JSON.parse(data.body);
-        addNewMessage([
-          {
-            id,
-            message,
-            senderId,
-            createdAt,
-          },
-        ]);
-      });
-    };
-
-    client.current.onWebSocketError = e => {
-      console.error(e);
-    };
-
-    client.current.activate();
-  };
-
-  const disconnect = () => {
-    client.current?.deactivate();
-  };
 
   useEffect(() => {
     if (currentSender !== user!.id && isScrollUpper)
@@ -80,20 +46,6 @@ function MessageContainer(props: MessageContainerProps) {
     if (!isScrollUpper) setExposureMessage("");
   }, [isScrollUpper]);
 
-  useEffect(() => {
-    connect();
-
-    return () => {
-      disconnect();
-    };
-  }, []);
-
-  useEffect(() => {
-    if (isFetchedAfterMount) {
-      addNewMessage(prevChatMessageList!);
-    }
-  }, [isFetchedAfterMount, prevChatMessageList]);
-
   return (
     <div className="relative mt-20 h-full w-full">
       <div
@@ -102,8 +54,8 @@ function MessageContainer(props: MessageContainerProps) {
         onScroll={handleScroll}
       >
         <>
-          {isLoading && <div>Loading...</div>}
-          {!isLoading &&
+          {isLoadMessage && <div>Loading...</div>}
+          {!isLoadMessage &&
             messageList.map(message => (
               <Message message={message} key={message.id} userId={user!.id} />
             ))}
@@ -116,7 +68,8 @@ function MessageContainer(props: MessageContainerProps) {
       />
       <MessageInput
         addNewMessage={addNewMessage}
-        clientRef={client}
+        publishSocketMessage={publishSocketMessage}
+        clientRef={clientRef}
         chatRoomId={chatRoomId}
       />
     </div>

--- a/app/chat/[id]/_components/MessageInput.tsx
+++ b/app/chat/[id]/_components/MessageInput.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import dayjs from "dayjs";
 import { Client } from "@stomp/stompjs";
 
 import { useAuthStore } from "@/app/_common/store/useAuthStore";
@@ -58,7 +59,7 @@ function MessageInput({
     publishSocketMessage(user!.id, message);
 
     const newMessage: MessageType = {
-      id: Number(Math.random().toString(36).slice(2, 9)), // TODO: 적절한 id로 변경 필요
+      id: dayjs().format("YYYY-MM-DDTHH:mm:ssZ"),
       message,
       senderId: user.id,
       createdAt: new Date().toISOString(),

--- a/app/chat/[id]/_components/MessageInput.tsx
+++ b/app/chat/[id]/_components/MessageInput.tsx
@@ -59,7 +59,7 @@ function MessageInput({
     publishSocketMessage(user!.id, message);
 
     const newMessage: MessageType = {
-      id: dayjs().format("YYYY-MM-DDTHH:mm:ssZ"),
+      id: dayjs().format("YYYY-MM-DDTHH:mm:ss:SSS"),
       message,
       senderId: user.id,
       createdAt: new Date().toISOString(),

--- a/app/chat/[id]/_components/MessageInput.tsx
+++ b/app/chat/[id]/_components/MessageInput.tsx
@@ -12,12 +12,14 @@ import useGetChats from "../../_api/useGetChats";
 
 interface MessageInputProp {
   addNewMessage: (newMessage: MessageType[]) => void;
+  publishSocketMessage: (userId: number, message: string) => void;
   clientRef: React.MutableRefObject<Client | null>;
   chatRoomId: string;
 }
 
 function MessageInput({
   addNewMessage,
+  publishSocketMessage,
   clientRef,
   chatRoomId,
 }: MessageInputProp) {
@@ -52,14 +54,8 @@ function MessageInput({
       !(clientRef.current && clientRef.current.connected && user)
     )
       return;
-    clientRef.current?.publish({
-      destination: `/app/chatroom/${chatRoomId}`,
-      body: JSON.stringify({
-        messageType: "TALK",
-        userId: user!.id,
-        message,
-      }),
-    });
+
+    publishSocketMessage(user!.id, message);
 
     const newMessage: MessageType = {
       id: Number(Math.random().toString(36).slice(2, 9)), // TODO: 적절한 id로 변경 필요

--- a/app/chat/[id]/_hooks/useGetPrevMessageList.ts
+++ b/app/chat/[id]/_hooks/useGetPrevMessageList.ts
@@ -21,7 +21,7 @@ export const useGetPrevMessageList = (chatRoomId: string) => {
 
       messages.push(...prevMessages);
 
-      cursorId = prevMessages[prevMessages.length - 1]?.id;
+      cursorId = Number(prevMessages[prevMessages.length - 1]?.id);
       hasData = hasNext;
     }
 

--- a/app/chat/_types/type.d.ts
+++ b/app/chat/_types/type.d.ts
@@ -1,5 +1,5 @@
 interface MessageType {
-  id: number;
+  id: string;
   message: string;
   senderId: number;
   createdAt?: string;


### PR DESCRIPTION
# 📌 작업 내용
- [x] useCustomMessage와 WebSocket 로직을 하나의 `Custom Hook`으로 생성
  - 하나의 `Custom Hook`으로 묶은 이유는 2가지 입니다.
    1. 두 로직 모두 메시지를 다룬다는 점과 각 로직에서 서로의 로직을 끌어다쓰는 점
    2. 채팅 페이지 외 채팅 카드에서도 동일한 로직을 사용한다는 점
- [x] 채팅 메시지의 `id` 설정 -> 기존 `random` 설정을 `dayjs()`를 사용하여 메시지 발신 시점(`string`)으로 설정했습니다.
- [x] 동일한 메시지가 2번 렌더링되는 현상 수정

-> 코드가 간결해졌고, 동일 로직을 재사용할 수 있습니다.
> 채팅 수신/발신 테스트했습니다!

# 🚦 특이 사항
> 처리되지 않은 로직이 있다면 말씀해주세요.

### 동일한 메시지가 2번 렌더링되는 현상
기본적으로 서버에서 본인이 발신한 메시지도 응답으로 보내주게 되어있습니다. 이를 메시지를 보낸 `senderId`와 `authStore`로 저장되어 있는 사용자 `id`를 비교하여 일치한다면 렌더링하지 않도록 수정했습니다.

### 채팅 로직 검증
배포 후, 실제로 프로젝트를 생성하고 채팅 로직에 대한 검증을 수행해야 합니다.

### 채팅 메시지 `id` 설정
기존에는 `random`으로 설정했으나, `dayjs()`를 사용하여 메시지의 발신 시점(`string`)을 `id`로 설정했습니다.
이전 PR에서 윤서님이 공유해주신 [nanoid](https://www.daleseo.com/nanoid/) 설치를 고려했으나 이미 설치되어 있는 라이브러리를 사용하는 것이 비용이 적다고 판단했고, **메시지의 발신 시점**으로도 충분히 동일한 `id`가 발생하지 않을 것이라고 판단했습니다.(현재 `dayjs().format("YYYY-MM-DDTHH:mm:ss:SSS")` 밀리세컨드까지 계산)

close #228 