### PR TITLE
[feat] 하단 네비게이션 바 페이지별 삽입

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import WithNavigation from "../_common/hoc/WithNavigation";
 import StackNavigator from "../_common/components/StackNavigator";
 import ChatList from "./_components/ChatList";
 
@@ -12,4 +13,4 @@ function ChatPage() {
   );
 }
 
-export default ChatPage;
+export default WithNavigation(ChatPage, true);

--- a/app/my-page/page.tsx
+++ b/app/my-page/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import WithNavigation from "../_common/hoc/WithNavigation";
 import StackNavigator from "../_common/components/StackNavigator";
 import { useQueryUserData } from "./_hooks/useQueryUserData";
 import { useQuerySendLikeCount } from "./_hooks/useQuerySendLikeCount";
@@ -44,4 +45,4 @@ function MyPage() {
   );
 }
 
-export default MyPage;
+export default WithNavigation(MyPage, true);

--- a/app/my-page/page.tsx
+++ b/app/my-page/page.tsx
@@ -30,7 +30,7 @@ function MyPage() {
   }
 
   return (
-    <main className="container flex min-h-screen max-w-2xl flex-col gap-8 bg-gray-50 pb-8 dark:bg-gray-950">
+    <main className="container flex min-h-screen max-w-2xl flex-col gap-8 bg-gray-50 pb-24 dark:bg-gray-950">
       <StackNavigator element={"마이페이지"} />
       <Profile data={userData} />
       <LikeCounter

--- a/app/project/page.tsx
+++ b/app/project/page.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import WithNavigation from "../_common/hoc/WithNavigation";
 import ProjectManageSection from "./_components/ProjectManageSection";
 
 function ProjectPage() {
@@ -10,4 +11,4 @@ function ProjectPage() {
   );
 }
 
-export default ProjectPage;
+export default WithNavigation(ProjectPage, true);


### PR DESCRIPTION
# 📌 작업 내용

- 마이페이지, 채팅, 프로젝트 관리 페이지에 생성해둔 `WithNavigation` HOC를 사용
- 마이페이지는 하단 네비게이션 바가 카드를 가려 하단 패딩값 변경

# 🚦 특이 사항

- 필요한 페이지에만 hoc를 넣으면 되는 것 같아서 `isShowNavigation` 조건이 필요한지 잘 모르겠습니다 ..! 혹은 제가 의도에 맞지 않게 이상하게 사용한 것인지 궁금합니다 ,, 
- 또한 `StackNavigator` 컴포넌트도 `WithNavigation`에 넣으면 어떤가 하는 생각이 들었습니다! 같은 네비게이션 속성이라서 한번에 처리 하는게 컴포넌트 이름에도 더 맞는 것 같다는 생각이 드는데, 좋은 생각인지 모르겠습니다.

close #235