### PR TITLE
[feat] 유저 정보가 없는 경우 하단 네비게이션 바 접근 금지 토스트 추가

### DIFF
--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -118,7 +118,7 @@ function Map() {
       <div className="map-background" />
       <LoadingSpinner
         className={cn(
-          "absolute bottom-0 left-0 right-0 top-0 z-10 flex h-full w-full place-content-center bg-black/40 backdrop-blur-sm transition-all duration-300",
+          "absolute bottom-0 left-0 right-0 top-0 z-100 flex h-full w-full place-content-center bg-black/40 backdrop-blur-sm transition-all duration-300",
           isRankLoading ? "visible opacity-100" : "invisible opacity-0",
         )}
       />

--- a/app/_common/components/NavigationBottom.tsx
+++ b/app/_common/components/NavigationBottom.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { MouseEvent } from "react";
 import { usePathname } from "next/navigation";
 
 import { navigate } from "../utils/redirect";
@@ -7,6 +8,10 @@ import { Menubar, MenubarMenu, MenubarTrigger } from "../shadcn/ui/menubar";
 
 function NavigationBottom() {
   const pathname = usePathname();
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    const path = (event.target as HTMLButtonElement).value;
+    navigate(path);
+  };
 
   return (
     <Menubar
@@ -15,7 +20,8 @@ function NavigationBottom() {
     >
       <MenubarMenu value="/">
         <MenubarTrigger
-          onClick={() => navigate("/")}
+          value="/"
+          onClick={handleClick}
           className="inline-block min-w-20"
         >
           지도
@@ -23,7 +29,8 @@ function NavigationBottom() {
       </MenubarMenu>
       <MenubarMenu value="/my-page">
         <MenubarTrigger
-          onClick={() => navigate("/my-page")}
+          value="/my-page"
+          onClick={handleClick}
           className="inline-block min-w-20"
         >
           마이
@@ -31,7 +38,8 @@ function NavigationBottom() {
       </MenubarMenu>
       <MenubarMenu value="/chat">
         <MenubarTrigger
-          onClick={() => navigate("/chat")}
+          value="/chat"
+          onClick={handleClick}
           className="inline-block min-w-20"
         >
           채팅
@@ -39,7 +47,8 @@ function NavigationBottom() {
       </MenubarMenu>
       <MenubarMenu value="/project">
         <MenubarTrigger
-          onClick={() => navigate("/project")}
+          value="/project"
+          onClick={handleClick}
           className="inline-block min-w-20"
         >
           모각고

--- a/app/_common/components/NavigationBottom.tsx
+++ b/app/_common/components/NavigationBottom.tsx
@@ -32,12 +32,16 @@ function NavigationBottom() {
     <Menubar
       defaultValue={pathname}
       className="fixed bottom-8 left-2/4 z-100 -translate-x-2/4 shadow-neo-b"
+      onClick={!getUser() ? handleNoAuthClick : () => {}}
     >
       <MenubarMenu value="/">
         <MenubarTrigger
           value="/"
           onClick={handleNavigateClick}
-          className="inline-block min-w-20"
+          className={cn(
+            "inline-block min-w-20",
+            !getUser() ? "pointer-events-none" : "",
+          )}
         >
           지도
         </MenubarTrigger>
@@ -46,7 +50,10 @@ function NavigationBottom() {
         <MenubarTrigger
           value="/my-page"
           onClick={handleNavigateClick}
-          className="inline-block min-w-20"
+          className={cn(
+            "inline-block min-w-20",
+            !getUser() ? "pointer-events-none" : "",
+          )}
         >
           마이
         </MenubarTrigger>
@@ -55,7 +62,10 @@ function NavigationBottom() {
         <MenubarTrigger
           value="/chat"
           onClick={handleNavigateClick}
-          className="inline-block min-w-20"
+          className={cn(
+            "inline-block min-w-20",
+            !getUser() ? "pointer-events-none" : "",
+          )}
         >
           채팅
         </MenubarTrigger>
@@ -64,18 +74,14 @@ function NavigationBottom() {
         <MenubarTrigger
           value="/project"
           onClick={handleNavigateClick}
-          className="inline-block min-w-20"
+          className={cn(
+            "inline-block min-w-20",
+            !getUser() ? "pointer-events-none" : "",
+          )}
         >
           모각고
         </MenubarTrigger>
       </MenubarMenu>
-      <div
-        className={cn(
-          "fixed bottom-0 left-20 right-0 top-0 min-h-10",
-          getUser() && "hidden",
-        )}
-        onClick={handleNoAuthClick}
-      />
     </Menubar>
   );
 }

--- a/app/_common/components/NavigationBottom.tsx
+++ b/app/_common/components/NavigationBottom.tsx
@@ -3,12 +3,26 @@
 import { MouseEvent } from "react";
 import { usePathname } from "next/navigation";
 
+import { toast } from "../utils/toast";
 import { navigate } from "../utils/redirect";
+import { useAuthStore } from "../store/useAuthStore";
 import { Menubar, MenubarMenu, MenubarTrigger } from "../shadcn/ui/menubar";
 
 function NavigationBottom() {
   const pathname = usePathname();
+  const { getUser } = useAuthStore();
+
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    if (!getUser()) {
+      toast.warning("로그인 후 이용해주세요!", {
+        action: {
+          label: "로그인하기",
+          onClick: () => navigate("login"),
+        },
+      });
+      return;
+    }
+
     const path = (event.target as HTMLButtonElement).value;
     navigate(path);
   };

--- a/app/_common/components/NavigationBottom.tsx
+++ b/app/_common/components/NavigationBottom.tsx
@@ -32,6 +32,12 @@ function NavigationBottom() {
       defaultValue={pathname}
       className="fixed bottom-8 left-2/4 z-100 -translate-x-2/4 shadow-neo-b"
     >
+      <div
+        className={cn(
+          "fixed bottom-0 left-20 right-0 top-0 min-h-10",
+          getUser() && "hidden",
+        )}
+      />
       <MenubarMenu value="/">
         <MenubarTrigger
           value="/"

--- a/app/_common/components/NavigationBottom.tsx
+++ b/app/_common/components/NavigationBottom.tsx
@@ -13,7 +13,9 @@ function NavigationBottom() {
   const { getUser } = useAuthStore();
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
-    if (!getUser()) {
+    const path = (event.target as HTMLButtonElement).value;
+
+    if (!getUser() && path !== "/") {
       toast.warning("로그인 후 이용해주세요!", {
         action: {
           label: "로그인하기",
@@ -22,8 +24,6 @@ function NavigationBottom() {
       });
       return;
     }
-
-    const path = (event.target as HTMLButtonElement).value;
     navigate(path);
   };
 

--- a/app/_common/components/NavigationBottom.tsx
+++ b/app/_common/components/NavigationBottom.tsx
@@ -8,6 +8,7 @@ import { navigate } from "../utils/redirect";
 import { useAuthStore } from "../store/useAuthStore";
 import { cn } from "../shadcn/utils";
 import { Menubar, MenubarMenu, MenubarTrigger } from "../shadcn/ui/menubar";
+import WithOnMounted from "../hoc/WithOnMounted";
 
 function NavigationBottom() {
   const pathname = usePathname();
@@ -79,4 +80,4 @@ function NavigationBottom() {
   );
 }
 
-export default NavigationBottom;
+export default WithOnMounted(NavigationBottom);

--- a/app/_common/components/NavigationBottom.tsx
+++ b/app/_common/components/NavigationBottom.tsx
@@ -6,25 +6,25 @@ import { usePathname } from "next/navigation";
 import { toast } from "../utils/toast";
 import { navigate } from "../utils/redirect";
 import { useAuthStore } from "../store/useAuthStore";
+import { cn } from "../shadcn/utils";
 import { Menubar, MenubarMenu, MenubarTrigger } from "../shadcn/ui/menubar";
 
 function NavigationBottom() {
   const pathname = usePathname();
   const { getUser } = useAuthStore();
 
-  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const handleNavigateClick = (event: MouseEvent<HTMLButtonElement>) => {
     const path = (event.target as HTMLButtonElement).value;
-
-    if (!getUser() && path !== "/") {
-      toast.warning("로그인 후 이용해주세요!", {
-        action: {
-          label: "로그인하기",
-          onClick: () => navigate("login"),
-        },
-      });
-      return;
-    }
     navigate(path);
+  };
+
+  const handleNoAuthClick = () => {
+    toast.warning("로그인 후 이용해주세요!", {
+      action: {
+        label: "로그인하기",
+        onClick: () => navigate("login"),
+      },
+    });
   };
 
   return (
@@ -37,11 +37,12 @@ function NavigationBottom() {
           "fixed bottom-0 left-20 right-0 top-0 min-h-10",
           getUser() && "hidden",
         )}
+        onClick={handleNoAuthClick}
       />
       <MenubarMenu value="/">
         <MenubarTrigger
           value="/"
-          onClick={handleClick}
+          onClick={handleNavigateClick}
           className="inline-block min-w-20"
         >
           지도
@@ -50,7 +51,7 @@ function NavigationBottom() {
       <MenubarMenu value="/my-page">
         <MenubarTrigger
           value="/my-page"
-          onClick={handleClick}
+          onClick={handleNavigateClick}
           className="inline-block min-w-20"
         >
           마이
@@ -59,7 +60,7 @@ function NavigationBottom() {
       <MenubarMenu value="/chat">
         <MenubarTrigger
           value="/chat"
-          onClick={handleClick}
+          onClick={handleNavigateClick}
           className="inline-block min-w-20"
         >
           채팅
@@ -68,7 +69,7 @@ function NavigationBottom() {
       <MenubarMenu value="/project">
         <MenubarTrigger
           value="/project"
-          onClick={handleClick}
+          onClick={handleNavigateClick}
           className="inline-block min-w-20"
         >
           모각고

--- a/app/_common/components/NavigationBottom.tsx
+++ b/app/_common/components/NavigationBottom.tsx
@@ -33,13 +33,6 @@ function NavigationBottom() {
       defaultValue={pathname}
       className="fixed bottom-8 left-2/4 z-100 -translate-x-2/4 shadow-neo-b"
     >
-      <div
-        className={cn(
-          "fixed bottom-0 left-20 right-0 top-0 min-h-10",
-          getUser() && "hidden",
-        )}
-        onClick={handleNoAuthClick}
-      />
       <MenubarMenu value="/">
         <MenubarTrigger
           value="/"
@@ -76,6 +69,13 @@ function NavigationBottom() {
           모각고
         </MenubarTrigger>
       </MenubarMenu>
+      <div
+        className={cn(
+          "fixed bottom-0 left-20 right-0 top-0 min-h-10",
+          getUser() && "hidden",
+        )}
+        onClick={handleNoAuthClick}
+      />
     </Menubar>
   );
 }


### PR DESCRIPTION
# 📌 작업 내용
- 유저 정보가 없는 경우 하단 네비게이션 바 접근 금지 토스트 추가
- 하이라이팅을 막고 토스트 메시지를 띄우기 위하여 메뉴바 앨리먼트 위에 한 앨리면트를 추가하여 스토어에 유저 정보가 없으면 노출하여 클릭 시 토스트를 띄우게 하고, 있는 경우에는 감춤 처리를 했습니다.

![화면 기록 2024-03-20 오전 10 51 35](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/73841260/c6bedda5-4534-4a4d-a3ea-ce622e518ce3)

# 🚦 특이 사항
- ~메뉴바 하이라이팅을 막는 방법을 찾지 못했습니다. 비회원으로 이용할 수 있는 페이지가 지도 밖에 없어서 다행히 큰 문제는 없지만 하이라이팅도 막아야 좋을 것 같은데 찾기가 어려운 것 같습니다 ,,!~

close #239 