### PR TITLE
[refactor] 프로젝트 카드 & 프로필 카드 유저 업적 수정

### DIFF
--- a/app/_common/components/ProfileCard.tsx
+++ b/app/_common/components/ProfileCard.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import InfoPopover from "@/app/project/_components/InfoPopover";
 import ButtonRotate from "@/app/project/_components/ButtonRotate";
 import ButtonLike from "@/app/project/_components/ButtonLike";
+import { useQueryAchievements } from "@/app/achievements/_hooks/useQueryAchievements";
 import useToggleLikeProfile from "@/app/(map)/_api/useToggleLikeProfile";
 
 import { Profile } from "../types/profile";
@@ -48,6 +49,7 @@ function ProfileCard(props: ProfileCardProps) {
 
   const { user } = useAuthStore();
   const { toggleLikeProfile, isLiked } = useToggleLikeProfile();
+  const { myAchievement } = useQueryAchievements();
 
   const handleToggleButton = () => {
     if (!user) return;
@@ -101,7 +103,7 @@ function ProfileCard(props: ProfileCardProps) {
                 <span className="relative text-black">{username}</span>
               </h1>
               <h3 className="mt-3 text-xs font-bold text-[#F76A6A]">
-                {"이세계 개발자"}
+                {myAchievement?.title ?? "칭호가 없습니다."}
               </h3>
             </div>
             <p className="line-clamp-3 w-40 grow overflow-hidden text-center text-sm">

--- a/app/globals.css
+++ b/app/globals.css
@@ -36,9 +36,6 @@
   .main-logo {
     @apply absolute z-0 h-full  w-full overflow-hidden before:absolute before:right-[100%] before:h-full before:w-full before:animate-slide-infinite before:bg-[url("/images/main_logo.webp")] before:bg-[length:100%] before:content-[""] after:absolute after:h-full after:w-full after:animate-slide-infinite after:bg-[url("/images/main_logo.webp")] after:bg-[length:100%] after:content-[""];
   }
-  .card {
-   
-  }
 }
 
 @layer utilities {

--- a/app/project/_components/ProjectCardContainer.tsx
+++ b/app/project/_components/ProjectCardContainer.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 
+import { useQueryAchievements } from "@/app/achievements/_hooks/useQueryAchievements";
 import { cn } from "@/app/_common/shadcn/utils";
 import {
   Tabs,
@@ -34,6 +35,8 @@ function ProjectCardContainer({ project }: Props) {
     cursorId,
     project.creator.id,
   );
+  const { myAchievement } = useQueryAchievements();
+
   useEffect(() => {
     if (!data || "timestamp" in data) return;
     if (data) {
@@ -59,7 +62,11 @@ function ProjectCardContainer({ project }: Props) {
             `${flipped ? "[transform:rotateY(180deg)]" : ""}`,
           )}
         >
-          <ProjectCardFront onRotate={handleFlip} project={project} />
+          <ProjectCardFront
+            onRotate={handleFlip}
+            project={project}
+            achievementTitle={myAchievement?.title}
+          />
           <ProjectCardBack
             onRotate={handleFlip}
             requestList={requestList}

--- a/app/project/_components/ProjectCardFront.tsx
+++ b/app/project/_components/ProjectCardFront.tsx
@@ -41,6 +41,7 @@ interface CardFrontProps {
   initialRotate?: boolean;
   onRotate: () => void;
   project: Project;
+  achievementTitle?: string;
 }
 
 function ProjectCardFront(props: CardFrontProps) {
@@ -63,6 +64,7 @@ function ProjectCardFront(props: CardFrontProps) {
       projectId,
       meetingInfo: { meetDetail, meetEndTime, meetStartTime },
     },
+    achievementTitle,
   } = props;
   const { user } = useAuthStore();
 
@@ -135,7 +137,7 @@ function ProjectCardFront(props: CardFrontProps) {
                 <span className="relative text-black">{username}</span>
               </h1>
               <h3 className="mt-3 text-xs font-bold text-[#F76A6A]">
-                {"이세계 개발자"}
+                {achievementTitle ?? "칭호가 없습니다."}
               </h3>
             </div>
             <p className="line-clamp-3 w-40 overflow-hidden text-center text-sm">

--- a/app/project/_components/ProjectManageSection.tsx
+++ b/app/project/_components/ProjectManageSection.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect } from "react";
 
 import { useMatchingStore } from "@/app/_common/store/useMatchingStore";
+import { cn } from "@/app/_common/shadcn/utils";
 import { useToast } from "@/app/_common/shadcn/ui/use-toast";
 
 import useGetCurrentProjectQuery from "../_hooks/useGetCurrentProjectQuery";
@@ -29,12 +30,17 @@ function ProjectManageSection() {
   }, [matchingId]);
 
   return (
-    <main className="relative flex h-full w-full flex-col items-center">
+    <main
+      className={cn(
+        "relative flex h-full w-full flex-col items-center",
+        !project ? "justify-center" : "",
+      )}
+    >
       <div className="map-background" />
       <div className="map-background" />
       {!project && (
-        <div className="flex h-[300px] flex-col items-center justify-between rounded-xl border-4 border-dotted p-10 md:h-[550px]">
-          <header className="space-y-3 text-center text-[#7b7b7b]">
+        <div className="z-10 flex h-[300px] flex-col items-center justify-between rounded-xl border-4 border-dotted border-black p-10 md:h-[550px]">
+          <header className="space-y-3 text-center">
             <h1 className="text-lg font-bold">생성한 프로젝트가 없어요!</h1>
             <h2 className="text-sm">프로젝트를 새로 생성해주세요.</h2>
           </header>


### PR DESCRIPTION
# 📌 작업 내용
- [x] 유저 업적 가져오는 로직 추가

# 🚦 특이 사항
- 기존에 사용하던 `useQueryAchievements` 쿼리 훅을 사용했습니다.
- 업적을 의미하는 `achievementTitle`에서 `achievementId`로 변경됨에 따라 업적을 가져오는 로직을 추가했습니다.

close #250 
