### PR TITLE
[fix] 마이페이지 useAuthStore 훅 교체

### DIFF
--- a/app/my-page/history/page.tsx
+++ b/app/my-page/history/page.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState } from "react";
 
-import { useAuthStore } from "@/app/_common/store/useAuthStore";
 import { cn } from "@/app/_common/shadcn/utils";
 import {
   Menubar,
@@ -15,6 +14,7 @@ import StackNavigator from "@/app/_common/components/StackNavigator";
 
 import { MatchStatus } from "@/app/_common/types/matching";
 
+import { useQueryUserData } from "../_hooks/useQueryUserData";
 import { useInfiniteQueryProjectHistory } from "../_hooks/useInfiniteQueryProjectHistory";
 import ProjectCardSkeleton from "../_components/ProjectCardSkeleton";
 import ProjectCard from "../_components/ProjectCard";
@@ -34,7 +34,7 @@ function HistoryPage() {
     [currentTab],
   );
 
-  const { user } = useAuthStore();
+  const { data: user } = useQueryUserData();
   const { data, fetchNextPage, hasNextPage, isFetching, isPending } =
     useInfiniteQueryProjectHistory(user?.id, statusQuery);
 

--- a/app/my-page/likes/page.tsx
+++ b/app/my-page/likes/page.tsx
@@ -2,17 +2,17 @@
 
 import { useMemo } from "react";
 
-import { useAuthStore } from "@/app/_common/store/useAuthStore";
 import { Button } from "@/app/_common/shadcn/ui/button";
 
 import StackNavigator from "@/app/_common/components/StackNavigator";
 
+import { useQueryUserData } from "../_hooks/useQueryUserData";
 import { useInfiniteQueryLikes } from "../_hooks/useInfiniteQueryLikes";
 import UserCardSkeleton from "../_components/UserCardSkeleton";
 import UserCard from "../_components/UserCard";
 
 function LikesPage() {
-  const { user } = useAuthStore();
+  const { data: user } = useQueryUserData();
   const { data, fetchNextPage, hasNextPage, isFetching, isPending } =
     useInfiniteQueryLikes(user?.id);
 

--- a/app/my-page/my-project/page.tsx
+++ b/app/my-page/my-project/page.tsx
@@ -2,17 +2,17 @@
 
 import { useMemo } from "react";
 
-import { useAuthStore } from "@/app/_common/store/useAuthStore";
 import { Button } from "@/app/_common/shadcn/ui/button";
 
 import StackNavigator from "@/app/_common/components/StackNavigator";
 
+import { useQueryUserData } from "../_hooks/useQueryUserData";
 import { useInfiniteQueryProjectList } from "../_hooks/useInfiniteQueryProjectList";
 import ProjectCardSkeleton from "../_components/ProjectCardSkeleton";
 import ProjectCard from "../_components/ProjectCard";
 
 function MyProjectPage() {
-  const { user } = useAuthStore();
+  const { data: user } = useQueryUserData();
   const { data, fetchNextPage, hasNextPage, isFetching, isPending } =
     useInfiniteQueryProjectList(user?.id);
 

--- a/app/my-page/requests/page.tsx
+++ b/app/my-page/requests/page.tsx
@@ -2,17 +2,17 @@
 
 import { useMemo } from "react";
 
-import { useAuthStore } from "@/app/_common/store/useAuthStore";
 import { Button } from "@/app/_common/shadcn/ui/button";
 
 import StackNavigator from "@/app/_common/components/StackNavigator";
 
+import { useQueryUserData } from "../_hooks/useQueryUserData";
 import { useInfiniteQueryProjectRequests } from "../_hooks/useInfiniteQueryProjectRequests";
 import ProjectCardSkeleton from "../_components/ProjectCardSkeleton";
 import ProjectCard from "../_components/ProjectCard";
 
 function ProjectRequestsPage() {
-  const { user } = useAuthStore();
+  const { data: user } = useQueryUserData();
   const { data, fetchNextPage, hasNextPage, isFetching, isPending } =
     useInfiniteQueryProjectRequests(user?.id);
 


### PR DESCRIPTION
# 📌 작업 내용
- [x] 마이페이지에서 사용되는 `useAuthStore` 훅을 `useQueryUserData` 훅으로 교체합니다. 

# 🚦 특이 사항
- 현재 로그인시 AuthStore가 갱신되고 있지 않아 `useAuthStore` 훅을 사용할 수 없어 `useQueryUserData` 훅으로 변경하였습니다.

close #261 
