### PR TITLE
[style] 공통 버튼 컴포넌트 텍스트 색상 추가 

### DIFF
--- a/app/_common/shadcn/ui/button.tsx
+++ b/app/_common/shadcn/ui/button.tsx
@@ -10,11 +10,11 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "rounded-md border border-black bg-white px-10 py-3 font-bold shadow-neo transition-all active:translate-x-[3px] active:translate-y-[3px] active:shadow-none ",
+          "rounded-md border border-black bg-white px-10 py-3 font-bold text-black shadow-neo transition-all active:translate-x-[3px] active:translate-y-[3px] active:shadow-none",
         destructive:
           "bg-red-500 text-slate-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/90",
         outline:
-          "rounded-md border-2 border-black bg-white px-10 py-3 font-bold shadow-neo-b transition-all active:translate-x-[3px] active:translate-y-[3px] active:shadow-none",
+          "rounded-md border-2 border-black bg-white px-10 py-3 font-bold text-black shadow-neo-b transition-all active:translate-x-[3px] active:translate-y-[3px] active:shadow-none",
         secondary:
           "bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80",
         ghost:


### PR DESCRIPTION
# 📌 작업 내용
- [x] 다크 모드에서도 정상적으로 보이도록 텍스트 컬러 추가

# 🚦 특이 사항
- 다크 모드에서 버튼이 정상적으로 보이지 않아 텍스트 컬러를 추가로 지정하였습니다.
<img src="https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/86952779/d8a48320-2005-40bd-bdaf-af13cb7f9a03" alt="image1" width="400px" />
<img src="https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/86952779/98d4d4c0-7313-49f3-a23f-d4fae1933999" alt="image2" width="400px" />

close #270 