### PR TITLE
[fix] 쿠키 삭제시 path 옵션 제공

### DIFF
--- a/app/_common/utils/cookie.ts
+++ b/app/_common/utils/cookie.ts
@@ -34,10 +34,14 @@ export async function getCookie<T>(key: string, defaultValue?: Promise<T>) {
   }
 }
 
-export async function deleteCookie(key: string) {
+export async function deleteCookie(
+  key: string,
+  options?: Partial<Omit<ResponseCookie, "maxAge">>,
+) {
   try {
     const response = await axios.post("/api/delete-cookie", {
       key,
+      options,
     });
 
     return response;

--- a/app/api/delete-cookie/route.ts
+++ b/app/api/delete-cookie/route.ts
@@ -1,14 +1,23 @@
-export async function POST(request: Request) {
+import { NextRequest } from "next/server";
+
+export async function POST(request: NextRequest) {
   const body = await request.json();
 
   if (!("key" in body)) {
     return new Response(undefined, { status: 400 });
   }
 
+  const options = {
+    ...(body.options ?? {}),
+    "Max-age": 0,
+  };
+
   return new Response(undefined, {
     status: 200,
     headers: {
-      "Set-Cookie": `${body.key}=; Max-age=0`,
+      "Set-Cookie": `${body.key}=; ${Object.entries(options)
+        .map(([key, value]) => `${key}=${value}`)
+        .join("; ")}`,
     },
   });
 }

--- a/app/api/set-cookie/route.ts
+++ b/app/api/set-cookie/route.ts
@@ -11,7 +11,7 @@ export async function POST(request: Request) {
       "Set-Cookie": `${body.key}=${body.value}; ${Object.entries(
         body.options ?? {},
       )
-        .map(el => `${el[0]}=${el[1]}`)
+        .map(([key, value]) => `${key}=${value}`)
         .join("; ")}`,
     },
   });

--- a/app/login/_hooks/useMutationLogin.ts
+++ b/app/login/_hooks/useMutationLogin.ts
@@ -18,7 +18,6 @@ const saveUpdatedTokens = (newAccessToken: string, newRefreshToken: string) => {
   setCookie("refreshToken", newRefreshToken, {
     httpOnly: true,
     "max-age": 60 * 60 * 24 * 14,
-    path: "/",
   });
 };
 

--- a/app/signup/_hooks/useMutationSignup.ts
+++ b/app/signup/_hooks/useMutationSignup.ts
@@ -22,7 +22,6 @@ export const useMutationSignup = (
       setCookie("refreshToken", refreshToken, {
         httpOnly: true,
         "max-age": 60 * 60 * 24 * 14,
-        path: "/",
       });
 
       sessionStorage.removeItem("accessToken");


### PR DESCRIPTION
# 📌 작업 내용
- [x] 쿠키 삭제시 path 옵션을 제공하도록 수정
- [x] 'refreshToken' 저장시 옵션없이 저장되도록 변경

# 🚦 특이 사항
- 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점을 작성해주세요.
- 현재 'refreshToken' 저장시 path 옵션이 '/'로 지정되어 있어 쿠키 삭제시 path가 일치하지 않는 문제가 있었습니다.
우선 'refreshToken' 저장시 path 옵션을 지정하는 대신 기본값을 사용하도록 변경하였고 
쿠키 삭제시 path 옵션을 제공하여 원하는 path의 쿠키를 삭제할 수 있도록 하였습니다.
![image](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/86952779/5712b9bd-cd3b-4c24-bef1-3c888066aa2a)
![image](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/86952779/75215c49-9490-4dd8-b425-75ae4a7ff708)


