### PR TITLE
[fix] GPS 허용 안내 모달 여러 번 뜨는 버그

### DIFF
--- a/app/auth-mylocation/_hooks/useQueryGeoAreaCode.ts
+++ b/app/auth-mylocation/_hooks/useQueryGeoAreaCode.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { usePositionStore } from "@/app/_common/store/usePositionStore";
@@ -8,8 +9,14 @@ import { checkInstanceOfResponseError } from "@/app/_common/utils/checkInstanceO
 const useQueryGeoAreaCode = () => {
   const { getPosition, isAllowGPS, setPosition } = usePositionStore();
   const { latitude, longitude } = getPosition();
+  const [isTrigger, setIsTrigger] = useState(true);
 
-  if (!isAllowGPS() || (!latitude && !longitude)) setPosition();
+  if (!isAllowGPS() || (!latitude && !longitude)) {
+    if (isTrigger) {
+      setPosition();
+      setIsTrigger(false);
+    }
+  }
 
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ["geoAreaCode"],

--- a/app/auth-mylocation/_hooks/useQueryGeoAreaCode.ts
+++ b/app/auth-mylocation/_hooks/useQueryGeoAreaCode.ts
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { usePositionStore } from "@/app/_common/store/usePositionStore";
@@ -8,11 +7,6 @@ import { checkInstanceOfResponseError } from "@/app/_common/utils/checkInstanceO
 
 const useQueryGeoAreaCode = () => {
   const { getPosition, isAllowGPS, setPosition } = usePositionStore();
-
-  useEffect(() => {
-    getPosition();
-  }, [getPosition]);
-
   const { latitude, longitude } = getPosition();
 
   if (!isAllowGPS() || (!latitude && !longitude)) setPosition();

--- a/app/signup/_components/SignupForm.tsx
+++ b/app/signup/_components/SignupForm.tsx
@@ -64,14 +64,7 @@ function SignupForm() {
     signUp.mutate(data);
   };
 
-  if (!userData || !languages)
-    return (
-      <LoadingSpinner
-        width="100"
-        height="100"
-        className="grid h-screen w-screen place-content-center"
-      />
-    );
+  if (!userData || !languages) return <LoadingSpinner />;
 
   return (
     <>


### PR DESCRIPTION
# 📌 작업 내용

Map에서 렌더링이 3번 일어나 `useQueryGeoAreaCode` 훅도 세 번 호출이 됩니다.
세 번 중 하나는 프로젝트 밀집 순위 때문에 일어나는데 해결할 방법이 마땅히 떠오르지 않아 우선 `useQueryGeoAreaCode` 훅에 상태를 하나 추가하여 첫 번째 호출 때에만 geolocation 수집을 하도록 처리했습니다.

![화면 기록 2024-03-21 오후 3 03 37](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/73841260/5df5536e-ba6e-4e2c-a28a-c68ba6c5fb62)


# 🚦 특이 사항
- 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점을 작성해주세요.
- 좋은 방법을 추천해주신다면 감사하겠습니다

close #283