### PR TITLE
[feat] 지역별 프로필 카드 비회원용 조회 public api 연결

### DIFF
--- a/app/(map)/_api/useGetCardList.ts
+++ b/app/(map)/_api/useGetCardList.ts
@@ -1,6 +1,7 @@
 import { useRef } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 
+import { useAuthStore } from "@/app/_common/store/useAuthStore";
 import { getProjectCard } from "@/app/_common/api/project";
 import { getProfileCard } from "@/app/_common/api/profile";
 
@@ -13,6 +14,7 @@ import { formatRegionName } from "../_utils/formatRegionName";
 const useGetCardList = (regionCode: number) => {
   const region = formatRegionName(regionCode).toUpperCase();
   const isGetProfile = useRef(false);
+  const { getUser } = useAuthStore();
 
   const {
     data: projectList,
@@ -46,7 +48,11 @@ const useGetCardList = (regionCode: number) => {
   } = useInfiniteQuery({
     queryKey: ["profile-list", region] as const,
     queryFn: ({ pageParam = 0 }) => {
-      return getProfileCard({ region, cursorId: pageParam });
+      return getProfileCard({
+        region,
+        cursorId: pageParam,
+        isPublic: !getUser(),
+      });
     },
     initialPageParam: 0,
     getNextPageParam: lastPage => {

--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -5,7 +5,6 @@ import { EmblaCarouselType } from "embla-carousel";
 
 import useQueryGeoAreaCode from "@/app/auth-mylocation/_hooks/useQueryGeoAreaCode";
 import { usePositionStore } from "@/app/_common/store/usePositionStore";
-import { useAuthStore } from "@/app/_common/store/useAuthStore";
 import { cn } from "@/app/_common/shadcn/utils";
 import { Carousel, CarouselApi } from "@/app/_common/shadcn/ui/carousel";
 import WithNavigation from "@/app/_common/hoc/WithNavigation";
@@ -17,7 +16,6 @@ import Icon from "@/app/_common/components/Icon";
 import REGION_CODE from "@/app/_common/constants/regionCode";
 
 import { toast } from "@/app/_common/utils/toast";
-import { navigate } from "@/app/_common/utils/redirect";
 
 import { formatRegionName } from "../_utils/formatRegionName";
 import useGetRank from "../_api/useGetRank";
@@ -40,7 +38,6 @@ function Map() {
     hasNextProfile,
   } = useGetCardList(regionCode);
   const [carouselApi, setCarouselApi] = useState<CarouselApi>();
-  const { getUser } = useAuthStore();
 
   useEffect(() => {
     if (!carouselApi) return;
@@ -79,16 +76,6 @@ function Map() {
 
     const target = event.target as SVGElement | HTMLElement;
     const isRegion = target.tagName === "path";
-    if (!getUser() && isRegion) {
-      toast.info("유저 정보가 없습니다. 로그인 후 이용해주세요!", {
-        action: {
-          label: "로그인하기",
-          onClick: () => navigate("/login"),
-        },
-      });
-      return;
-    }
-
     const map = document.querySelector("#map-wrap") as HTMLDivElement;
     const isZoomIn = map.style.transform.includes("scale");
     if (isZoomIn) {

--- a/app/_common/api/profile.ts
+++ b/app/_common/api/profile.ts
@@ -26,7 +26,7 @@ export const getProfileCard = async ({
   const query = `${cursorId ? `cursorId=${cursorId}&` : ""}pageSize=5&sortOrder=ASC`;
   const publicUrl = isPublic ? "/public" : "";
   const { data } = await instance.get<ResponseData<Profile>>(
-    `/profiles/${region}?${query}`,
+    `${publicUrl}/profiles/${region}?${query}`,
   );
   return data;
 };

--- a/app/_common/api/profile.ts
+++ b/app/_common/api/profile.ts
@@ -15,13 +15,16 @@ import { instance } from "./instance";
 interface ProfileCardRequest {
   region: string;
   cursorId?: number;
+  isPublic: boolean;
 }
 
 export const getProfileCard = async ({
   region,
   cursorId,
+  isPublic,
 }: ProfileCardRequest) => {
   const query = `${cursorId ? `cursorId=${cursorId}&` : ""}pageSize=5&sortOrder=ASC`;
+  const publicUrl = isPublic ? "/public" : "";
   const { data } = await instance.get<ResponseData<Profile>>(
     `/profiles/${region}?${query}`,
   );

--- a/app/_common/components/NavigationBottom.tsx
+++ b/app/_common/components/NavigationBottom.tsx
@@ -20,7 +20,7 @@ function NavigationBottom() {
   };
 
   const handleNoAuthClick = () => {
-    toast.warning("로그인 후 이용해주세요!", {
+    toast.info("로그인 후 이용해주세요!", {
       action: {
         label: "로그인하기",
         onClick: () => navigate("login"),


### PR DESCRIPTION
# 📌 작업 내용
- 지역별 프로필 카드 비회원용 조회 public api 연결하여 스토어에 저장된 유저 정보에 따라 비회원 여부 판단
- 비회원일 때 지역 클릭 못하게 하는 로직 제거
- warning 토스트 메시지가 잘 안 보여 info로 변경

아래는 비회원인 경우에 프로필 카드를 조회하는 영상 입니다.

![화면 기록 2024-03-22 오전 10 51 21](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/73841260/aaa15670-c544-4286-a5c5-9499a6af2248)

# 🚦 특이 사항
- 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점을 작성해주세요.

close #291