### PR TITLE
[fix] iOS PWA 환경에서 외부 링크 실행시 뷰포트 높이가 줄어드는 버그 해결

### DIFF
--- a/app/(map)/_components/Map.tsx
+++ b/app/(map)/_components/Map.tsx
@@ -112,7 +112,7 @@ function Map() {
   };
 
   return (
-    <div className="relative h-screen w-screen touch-none overflow-hidden">
+    <div className="relative h-full w-screen touch-none overflow-hidden">
       <Icon
         id="vertical-logo"
         height={200}
@@ -129,7 +129,7 @@ function Map() {
       <div
         id="map-wrap"
         onClick={handleRegionClick}
-        className="absolute z-0 flex h-screen w-screen touch-none items-center justify-center transition-all duration-1000"
+        className="absolute z-0 flex h-full w-screen touch-none items-center justify-center transition-all duration-1000"
       >
         <MapComponent
           regionCode={regionCode}
@@ -138,7 +138,7 @@ function Map() {
       </div>
       <Carousel
         className={cn(
-          "z-60 h-screen w-screen transition-all delay-0 duration-300",
+          "z-60 h-full w-screen transition-all delay-0 duration-300",
           isListShow ? "visible opacity-100 delay-1000" : "invisible opacity-0",
         )}
         setApi={setCarouselApi}

--- a/app/_common/components/LoadingSpinner.tsx
+++ b/app/_common/components/LoadingSpinner.tsx
@@ -19,7 +19,7 @@ function LoadingSpinner({
   return (
     <div
       className={cn(
-        "flex h-screen w-full place-content-center bg-white",
+        "flex h-full w-full place-content-center bg-white",
         className,
       )}
     >

--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -16,7 +16,7 @@ async function ChattingRoomPage({
   const { name, profileImage } = searchParams;
 
   return (
-    <main className="flex h-screen flex-col items-center">
+    <main className="flex h-full flex-col items-center">
       <StackNavigator
         element={
           <Profile avatarUrl={profileImage} username={name}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -38,3 +38,9 @@
     -webkit-backdrop-filter: blur(7.5px);
   }
 }
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -13,7 +13,7 @@ export const viewport: Viewport = generateViewport(theme.GRAY);
 function LoginPage() {
   return (
     <Suspense fallback={<LoadingSpinner />}>
-      <main className="relatie flex h-screen w-full flex-col items-center bg-[#E8E8E8]">
+      <main className="relatie flex h-full w-full flex-col items-center bg-[#E8E8E8]">
         <Image
           className="absolute bottom-16 right-0"
           src={"/images/login_bg_imgs.png"}

--- a/app/my-page/delete/page.tsx
+++ b/app/my-page/delete/page.tsx
@@ -8,7 +8,7 @@ function DeletePage() {
   return (
     <>
       <StackNavigator element={"회원 탈퇴"} />
-      <main className="container flex min-h-screen max-w-2xl flex-col gap-8 pb-8">
+      <main className="container flex min-h-full max-w-2xl flex-col gap-8 pb-8">
         <div className="flex flex-col gap-4">
           {/* TODO: 추가 고지 사항 작성 */}
           <div className="text-sm">

--- a/app/my-page/edit/page.tsx
+++ b/app/my-page/edit/page.tsx
@@ -24,7 +24,7 @@ function EditPage() {
   return (
     <>
       <StackNavigator element={"수정"} />
-      <main className="container flex min-h-screen max-w-2xl flex-col gap-8 pb-8">
+      <main className="container flex min-h-full max-w-2xl flex-col gap-8 pb-8">
         {data ? (
           <EditForm defaultValues={data} />
         ) : (

--- a/app/my-page/history/page.tsx
+++ b/app/my-page/history/page.tsx
@@ -46,7 +46,7 @@ function HistoryPage() {
   return (
     <>
       <StackNavigator element={"지난 만남 카드"} />
-      <main className="container flex min-h-screen max-w-2xl flex-col gap-8 pb-8">
+      <main className="container flex min-h-full max-w-2xl flex-col gap-8 pb-8">
         <Menubar value={currentTab}>
           {MENUS.map(menu => (
             <MenubarMenu key={menu.id} value={menu.id}>

--- a/app/my-page/likes/page.tsx
+++ b/app/my-page/likes/page.tsx
@@ -24,7 +24,7 @@ function LikesPage() {
   return (
     <>
       <StackNavigator element={"내가 찔러보기한 사람"} />
-      <main className="container flex min-h-screen max-w-2xl flex-col gap-8 pb-8">
+      <main className="container flex min-h-full max-w-2xl flex-col gap-8 pb-8">
         <section className="flex flex-col gap-2">
           {users
             ? users.map(el => <UserCard key={el.createdAt} data={el} />)

--- a/app/my-page/my-project/page.tsx
+++ b/app/my-page/my-project/page.tsx
@@ -24,7 +24,7 @@ function MyProjectPage() {
   return (
     <>
       <StackNavigator element={"내가 생성한 프로젝트"} />
-      <main className="container flex min-h-screen max-w-2xl flex-col gap-8 pb-8">
+      <main className="container flex min-h-full max-w-2xl flex-col gap-8 pb-8">
         {/* TODO: currentTab 기준으로 필터링 */}
         <section className="flex flex-col gap-2">
           {projects

--- a/app/my-page/page.tsx
+++ b/app/my-page/page.tsx
@@ -26,6 +26,7 @@ function MyPage() {
       <Link href={"/notification"}>
         <Icon
           id="notification"
+          h-full
           size={24}
           className="absolute right-4 top-4 z-10"
         />

--- a/app/my-page/requests/page.tsx
+++ b/app/my-page/requests/page.tsx
@@ -24,7 +24,7 @@ function ProjectRequestsPage() {
   return (
     <>
       <StackNavigator element={"내가 보낸 요청"} />
-      <main className="container flex min-h-screen max-w-2xl flex-col gap-8 pb-8">
+      <main className="container flex min-h-full max-w-2xl flex-col gap-8 pb-8">
         <section className="flex flex-col gap-2">
           {projects
             ? projects.map(el => <ProjectCard key={el.projectId} data={el} />)

--- a/app/project/page.tsx
+++ b/app/project/page.tsx
@@ -11,7 +11,7 @@ export const viewport: Viewport = generateViewport(theme.SKY);
 
 function ProjectPage() {
   return (
-    <section className="h-screen w-full">
+    <section className="h-full w-full">
       <ProjectManageSection />
     </section>
   );

--- a/app/review/_components/ReviewSkeleton.tsx
+++ b/app/review/_components/ReviewSkeleton.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from "@/app/_common/shadcn/ui/skeleton";
 
 function ReviewSkeleton() {
   return (
-    <main className="map-background grid h-screen w-full place-items-center p-4">
+    <main className="map-background grid h-full w-full place-items-center p-4">
       <div className="z-10 flex flex-col place-content-center rounded-md border-2 border-black bg-white p-6 shadow-neo">
         <div className="space-y-14">
           <div className="space-y-2">

--- a/app/review/page.tsx
+++ b/app/review/page.tsx
@@ -12,7 +12,7 @@ export const viewport: Viewport = generateViewport(theme.SKY);
 function ReviewPage() {
   return (
     <Suspense fallback={<ReviewSkeleton />}>
-      <main className="map-background grid h-screen w-full place-items-center p-4">
+      <main className="map-background grid h-full w-full place-items-center p-4">
         <ReviewForm />
       </main>
     </Suspense>

--- a/app/signup/_components/SignupForm.tsx
+++ b/app/signup/_components/SignupForm.tsx
@@ -74,7 +74,7 @@ function SignupForm() {
 
       <main className="p-6">
         <Form {...form}>
-          <form className="h-screen" onSubmit={form.handleSubmit(onSubmit)}>
+          <form className="h-full" onSubmit={form.handleSubmit(onSubmit)}>
             <SignupFirstStep
               form={form}
               className={cn(


### PR DESCRIPTION
# 📌 작업 내용
- [x] `html`, `body` 태그에 `width`, `height` 속성 값으로 `100%` 적용
- [x] 페이지 최상단에서 사용되고 있는 `h-screen` 클래스 `h-full`로 대체

# 🚦 특이 사항
- iOS PWA 환경에서 웹킷 엔진 버그로 인해 외부 링크를 열었을때 뷰포트가 줄어들고 복구되지 않는 문제가 있습니다.
- 이로 인해 `h-screen`, `height: 100vh` 사용시 정상적인 높이로 설정되지 않아 하단에 빈공간이 생기게 되어 body의 배경색이 노출되게 됩니다.
- 이를 해결하고자 **`html`, `body` 태그에 `width`, `height` 속성 값으로 `100%` 적용**하여 항상 차지할 수 있는 최대 높이로 고정되게 했고 **각 페이지 최상단 컴포넌트에서는 `h-full` 클래스를 사용하면 기존 `h-screen`, `height: 100vh`와 동일한 효과**를 얻게 됩니다.
- **다만 최상단 컴포넌트가 아닌 경우 `h-full` 클래스를 적용하더라도 가능한 부모 요소의 높이 내에서 사용 가능한 최대 높이를 차지할 뿐 `h-screen`, `height: 100vh`와 동일한 효과를 기대할 수 없습니다.**

close #303 