### PR TITLE
[style] 다크모드 시 글씨색, 배경색, 뷰포트 색 수정

### DIFF
--- a/app/_common/components/ProfileCard.tsx
+++ b/app/_common/components/ProfileCard.tsx
@@ -100,7 +100,9 @@ function ProfileCard(props: ProfileCardProps) {
           <div className="flex grow flex-col items-center gap-4">
             <div className="flex flex-col items-center gap-1 p-1">
               <h1 className="text-2xl font-bold">
-                <span className="relative text-black">{username}</span>
+                <span className="relative text-black dark:text-white">
+                  {username}
+                </span>
               </h1>
               <h3 className="mt-3 text-xs font-bold text-[#F76A6A]">
                 {myAchievement?.title ?? "칭호가 없습니다."}

--- a/app/_common/components/StackNavigator.tsx
+++ b/app/_common/components/StackNavigator.tsx
@@ -15,6 +15,7 @@ function StackNavigator({
   element,
   path,
   className,
+  children,
   ...props
 }: StackNavigatorProps) {
   const router = useRouter();
@@ -31,7 +32,7 @@ function StackNavigator({
 
   return (
     <header
-      className={cn("relative p-4 text-center text-lg", className)}
+      className={cn("relative px-4 py-8 text-center text-lg", className)}
       {...props}
     >
       <Icon
@@ -41,6 +42,7 @@ function StackNavigator({
         onClick={!path ? handleBack : handlePushPath}
       />
       <h2>{element}</h2>
+      {children}
     </header>
   );
 }

--- a/app/_common/constants/viewPortTheme.ts
+++ b/app/_common/constants/viewPortTheme.ts
@@ -1,5 +1,14 @@
 export const theme = {
-  DEFAULT: "#ffffff",
-  SKY: "#7DD1F2",
-  GRAY: "#E8E8E8",
+  DEFAULT: {
+    light: "#FFFFFF",
+    dark: "#000000",
+  },
+  SKY: {
+    light: "#7DD1F2",
+    dark: "#7DD1F2",
+  },
+  GRAY: {
+    light: "#E8E8E8",
+    dark: "#E8E8E8",
+  },
 };

--- a/app/_common/shadcn/ui/menubar.tsx
+++ b/app/_common/shadcn/ui/menubar.tsx
@@ -40,7 +40,7 @@ const MenubarTrigger = React.forwardRef<
   <MenubarPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-full px-3 py-1.5 text-sm font-medium focus:bg-slate-100 focus:text-slate-900 data-[state=open]:bg-neoGreen data-[state=open]:text-white data-[state=open]:outline data-[state=open]:outline-2 data-[state=open]:outline-black dark:focus:bg-slate-800 dark:focus:text-slate-50 dark:data-[state=open]:bg-slate-800 dark:data-[state=open]:text-slate-50",
+      "flex cursor-default select-none items-center rounded-full px-3 py-1.5 text-sm font-medium focus:bg-slate-100 focus:text-slate-900 data-[state=open]:bg-neoGreen data-[state=open]:text-white data-[state=open]:outline data-[state=open]:outline-2 data-[state=open]:outline-black dark:focus:bg-slate-800 dark:focus:text-slate-50 dark:data-[state=open]:bg-neoGreen dark:data-[state=open]:text-slate-50",
       className,
     )}
     {...props}

--- a/app/_common/utils/generateViewport.ts
+++ b/app/_common/utils/generateViewport.ts
@@ -1,5 +1,16 @@
-export const generateViewport = (themeColor: string) => {
+interface generateViewportProps {
+  lightColor: string;
+  darkColor: string;
+}
+
+export const generateViewport = ({
+  lightColor,
+  darkColor,
+}: generateViewportProps) => {
   return {
-    themeColor,
+    themeColor: [
+      { media: "(prefers-color-scheme: light)", color: lightColor },
+      { media: "(prefers-color-scheme: dark)", color: darkColor },
+    ],
   };
 };

--- a/app/achievements/page.tsx
+++ b/app/achievements/page.tsx
@@ -4,7 +4,7 @@ import AchievementList from "./_components/AchievementList";
 function AchievementsPage() {
   return (
     <main className="p-4">
-      <StackNavigator element="활동 업적" />
+      <StackNavigator element="활동 업적" className="px-0 py-4" />
 
       <AchievementList />
     </main>

--- a/app/auth-mylocation/page.tsx
+++ b/app/auth-mylocation/page.tsx
@@ -4,7 +4,7 @@ import MyLocationAuth from "./_components/MyLocationAuth";
 function AuthMylocationPage() {
   return (
     <main className="p-4">
-      <StackNavigator element="내 위치 인증" />
+      <StackNavigator element="내 위치 인증" className="px-0 py-4" />
       <MyLocationAuth />
     </main>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import "dayjs/locale/ko";
 import { generateViewport } from "./_common/utils/generateViewport";
 import { Toaster } from "./_common/shadcn/ui/toaster";
 import { Toaster as Sonner } from "./_common/shadcn/ui/sonner";
+import { theme } from "./_common/constants/viewPortTheme";
 import { WebSocketProvider } from "./_common/components/WebSocketProvider";
 import { ThemeProvider } from "./_common/components/theme-provider";
 import SVGProvider from "./_common/components/SVGProvider";
@@ -20,7 +21,10 @@ export const metadata: Metadata = {
 
 dayjs.locale("ko");
 
-export const viewport: Viewport = generateViewport("#ffffff");
+export const viewport: Viewport = generateViewport({
+  lightColor: theme.DEFAULT.light,
+  darkColor: theme.DEFAULT.dark,
+});
 
 export default function RootLayout({
   children,

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -8,7 +8,10 @@ import LoginForm from "./_components/LoginForm";
 
 import type { Viewport } from "next";
 
-export const viewport: Viewport = generateViewport(theme.GRAY);
+export const viewport: Viewport = generateViewport({
+  lightColor: theme.GRAY.light,
+  darkColor: theme.GRAY.dark,
+});
 
 function LoginPage() {
   return (

--- a/app/my-page/page.tsx
+++ b/app/my-page/page.tsx
@@ -23,14 +23,14 @@ function MyPage() {
 
   return (
     <div className="relative">
-      <Link href={"/notification"}>
-        <Icon
-          id="notification"
-          size={24}
-          className="absolute right-4 top-4 z-10"
-        />
-      </Link>
-      <StackNavigator element={"마이페이지"} />
+      <StackNavigator element={"마이페이지"}>
+        <Link
+          href={"/notification"}
+          className="absolute right-5 top-9 z-10 -translate-y-[0.1rem]"
+        >
+          <Icon id="notification" size={24} />
+        </Link>
+      </StackNavigator>
       <main className="container flex min-h-screen max-w-2xl flex-col gap-8 pb-24">
         <Profile />
         <Badges />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,10 @@ import Map from "./(map)/_components/Map";
 
 import type { Viewport } from "next";
 
-export const viewport: Viewport = generateViewport(theme.SKY);
+export const viewport: Viewport = generateViewport({
+  lightColor: theme.SKY.light,
+  darkColor: theme.SKY.dark,
+});
 
 export default function Home() {
   return (

--- a/app/project/_components/ButtonLike.tsx
+++ b/app/project/_components/ButtonLike.tsx
@@ -12,7 +12,10 @@ function ButtonLike({ onClick, isLiked }: ButtonLikeProps) {
   return (
     <Button
       onClick={onClick}
-      className={cn("w-full", isLiked ? "text-neoRed" : "text-black")}
+      className={cn(
+        "w-full dark:bg-white",
+        isLiked ? "text-neoRed" : "text-black",
+      )}
     >
       <Icon id="follow-fulfill" />
     </Button>

--- a/app/project/_components/InfoPopover.tsx
+++ b/app/project/_components/InfoPopover.tsx
@@ -31,7 +31,7 @@ function InfoPopover(props: InfoPopoverProps) {
       <PopoverTrigger asChild>
         <Button
           variant="outline"
-          className="flex items-center gap-7 bg-transparent backdrop-blur-md"
+          className="flex items-center gap-7 bg-transparent backdrop-blur-md  dark:bg-white dark:text-black"
         >
           <span className="text-xs">{title}</span>
           <Icon id="chevron-right" className="h-6 w-6" />

--- a/app/project/_components/PlaceItem.tsx
+++ b/app/project/_components/PlaceItem.tsx
@@ -11,7 +11,7 @@ function PlaceItem(props: PlaceItemProps) {
 
   return (
     <li className="w-full text-left">
-      <h1 className="">{place_name}</h1>
+      <h1 className="dark:text-black">{place_name}</h1>
       <p className="w-full truncate text-xs text-[#858585]">
         {road_address_name}
       </p>

--- a/app/project/_components/ProjectCardFront.tsx
+++ b/app/project/_components/ProjectCardFront.tsx
@@ -139,7 +139,9 @@ function ProjectCardFront(props: CardFrontProps) {
           <div className="flex flex-col items-center gap-4">
             <div className="flex flex-col items-center gap-1 p-1">
               <h1 className="text-2xl font-bold">
-                <span className="relative text-black">{username}</span>
+                <span className="relative text-black dark:text-white">
+                  {username}
+                </span>
               </h1>
               <h3 className="mt-3 text-xs font-bold text-[#F76A6A]">
                 {achievementTitle ?? "칭호가 없습니다."}

--- a/app/project/page.tsx
+++ b/app/project/page.tsx
@@ -7,7 +7,10 @@ import ProjectManageSection from "./_components/ProjectManageSection";
 
 import type { Viewport } from "next";
 
-export const viewport: Viewport = generateViewport(theme.SKY);
+export const viewport: Viewport = generateViewport({
+  lightColor: theme.SKY.light,
+  darkColor: theme.SKY.dark,
+});
 
 function ProjectPage() {
   return (

--- a/app/review/page.tsx
+++ b/app/review/page.tsx
@@ -7,7 +7,10 @@ import ReviewForm from "./_components/ReviewForm";
 
 import type { Viewport } from "next";
 
-export const viewport: Viewport = generateViewport(theme.SKY);
+export const viewport: Viewport = generateViewport({
+  lightColor: theme.SKY.light,
+  darkColor: theme.SKY.dark,
+});
 
 function ReviewPage() {
   return (


### PR DESCRIPTION
# 📌 작업 내용
- 구현 내용 및 작업 했던 내역, 사진필요한 경우 선택적으로 첨부해주세요.
- 다크모드 시 메뉴바를 클릭하면 neoGreen 색으로 변하도록 수정했습니다.
- 다크모드 시 프로필/프로젝트 카드, 프로젝트 생성 카드에서 보이지 않는 글씨색을 보이도록 수정했습니다.
- 뷰포트 generator에 다크모드 인자를 추가하여, 다크모드에서 하얀색 바탕으로 뜨는 부분을 검은색으로 수정하였습니다.
- 마이 페이지, 채팅 페이지, 업적 페이지, 위치 인증 페이지의 StackNavigator 높이를 통일하였습니다.

# 🚦 특이 사항
![스크린샷 2024-03-22 오후 12 03 37](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/114740795/36821234-fd8a-458d-ad3b-dc114821a04b)
![스크린샷 2024-03-22 오후 12 26 13](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/114740795/e0619040-4306-4d6f-a892-ccf8cf5dc773)
![스크린샷 2024-03-22 오후 12 03 54](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/114740795/e6a8a051-925f-4098-adde-8249ce3fb1f6)
![스크린샷 2024-03-22 오후 12 07 44](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/114740795/b501ccfc-c08a-42fd-98c9-8e79154384c2)
![스크린샷 2024-03-22 오후 12 13 43](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/114740795/ae223243-bdb7-474d-9348-820c870fa526)

- stacknavigator 높이 통일
![스크린샷 2024-03-22 오후 12 47 30](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/114740795/ef0fda11-57c8-41e5-b71b-92bf6c94f737)
![스크린샷 2024-03-22 오후 12 47 35](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/114740795/462053ba-d3bf-4b4e-9358-43d0f1585cea)
![스크린샷 2024-03-22 오후 12 47 41](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/114740795/308739e2-c90f-4688-9e36-c554ce293ab1)
![스크린샷 2024-03-22 오후 12 47 47](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/114740795/9808dbdb-ef42-4a5f-b786-4afd3cb11c47)
