### PR TITLE
[hotfix] 데이터 오류로 인해 업적 페이지 임시 수정

### DIFF
--- a/app/achievements/_components/AchievementItem.tsx
+++ b/app/achievements/_components/AchievementItem.tsx
@@ -19,6 +19,7 @@ import Icon from "@/app/_common/components/Icon";
 import { Achievement } from "@/app/_common/types/user";
 
 import { calculateAchievement } from "../_utils/calculateAchievement";
+import { useMutationUserAchievement } from "../_hooks/useMutationUserAchievement";
 
 interface AchievementItemProps {
   styleType: "main" | "item";
@@ -34,6 +35,7 @@ function AchievementItem({
   isMyAchievement,
 }: AchievementItemProps) {
   const {
+    userId,
     achievementId,
     title,
     imgUrl,
@@ -43,8 +45,17 @@ function AchievementItem({
     progressCount,
   } = achievement;
 
+  const { mutate } = useMutationUserAchievement();
+
   const leftToComplete = requirementValue - progressCount;
   const isThreeOrLessLeftToComplete = leftToComplete <= 3;
+
+  const handleSubmitAchievement = () => {
+    mutate({
+      userId,
+      achievementId,
+    });
+  };
 
   return (
     <li
@@ -105,7 +116,8 @@ function AchievementItem({
           <AccordionContent className="space-y-2">
             <p className="px-2 text-white">획득방법: {description}</p>
             <div className="text-end">
-              {!isCompleted ? (
+              {/* TODO: 업적 서버 수정되면 isCompleted 조건 추가 */}
+              {leftToComplete > 0 ? (
                 <p
                   className={cn("text-xs", {
                     "font-semibold text-white": isThreeOrLessLeftToComplete,
@@ -116,11 +128,16 @@ function AchievementItem({
                   {isThreeOrLessLeftToComplete && "!"}
                 </p>
               ) : (
-                !isMyAchievement && (
-                  <Button className="row-span-3" variant={"outline"}>
+                leftToComplete <= 0 ||
+                (!isMyAchievement && (
+                  <Button
+                    className="row-span-3"
+                    variant={"outline"}
+                    onClick={handleSubmitAchievement}
+                  >
                     변경
                   </Button>
-                )
+                ))
               )}
             </div>
           </AccordionContent>

--- a/app/achievements/_components/AchievementList.tsx
+++ b/app/achievements/_components/AchievementList.tsx
@@ -28,6 +28,7 @@ function AchievementList() {
     isFetching,
     isPending,
     isFetched,
+    userId,
   } = useQueryAchievements(user?.id);
 
   const [sorting, setSorting] = useState<Achievement[]>([]);
@@ -40,7 +41,7 @@ function AchievementList() {
     if (isFetched) setSorting(achievements);
   }, [achievements, isFetched]);
 
-  if (isLoading) return <AchievementSkeleton />;
+  if (isLoading || !userId) return <AchievementSkeleton />;
 
   return (
     <main className="flex flex-col">
@@ -83,11 +84,10 @@ function AchievementList() {
         {sorting &&
           sorting.map((achievement, index) => (
             <AchievementItem
+              userId={userId}
               styleType="item"
               achievement={achievement}
-              isMyAchievement={
-                myAchievement?.achievementId === achievement.achievementId
-              }
+              myAchievement={myAchievement ?? null}
               key={index}
             />
           ))}

--- a/app/achievements/_hooks/useMutationUserAchievement.ts
+++ b/app/achievements/_hooks/useMutationUserAchievement.ts
@@ -1,19 +1,31 @@
+import { Dispatch, SetStateAction } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { SignUpUser } from "@/app/signup/_type/signup";
 import { patchUserAchievement } from "@/app/_common/api/achievements";
 
-export const useMutationUserAchievement = () => {
+import { toast } from "@/app/_common/utils/toast";
+
+export const useMutationUserAchievement = (
+  setIsMyAchievement: Dispatch<SetStateAction<boolean>>,
+  userId: SignUpUser["id"],
+) => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: patchUserAchievement,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["achievements", "user"],
+        queryKey: ["achievements", userId],
       });
+
+      toast.success("업적 변경이 완료 됐습니다.");
+
+      setIsMyAchievement(true);
     },
     onError: error => {
       console.error(error);
+      toast.error(error.message);
     },
   });
 

--- a/app/achievements/_hooks/useMutationUserAchievement.ts
+++ b/app/achievements/_hooks/useMutationUserAchievement.ts
@@ -15,10 +15,6 @@ export const useMutationUserAchievement = (
   const mutation = useMutation({
     mutationFn: patchUserAchievement,
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["achievements", userId],
-      });
-
       toast.success("업적 변경이 완료 됐습니다.");
 
       setIsMyAchievement(true);
@@ -26,6 +22,9 @@ export const useMutationUserAchievement = (
     onError: error => {
       console.error(error);
       toast.error(error.message);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["achievements", userId] });
     },
   });
 

--- a/app/achievements/_hooks/useQueryAchievements.ts
+++ b/app/achievements/_hooks/useQueryAchievements.ts
@@ -28,5 +28,6 @@ export const useQueryAchievements = (staticUserId?: number) => {
     isFetching,
     isPending,
     isFetched,
+    userId,
   };
 };

--- a/app/achievements/_utils/calculateAchievement.ts
+++ b/app/achievements/_utils/calculateAchievement.ts
@@ -8,6 +8,8 @@ export const calculateAchievement = (nowAchieved: number, total: number) => {
   //   throw new Error("현재값이 총값보다 큽니다.");
   // }
 
+  if (total - nowAchieved < 0) return 100;
+
   const percentage = (nowAchieved / total) * 100;
   return Math.floor(percentage);
 };


### PR DESCRIPTION
# 📌 작업 내용
- 구현 내용 및 작업 했던 내역, 사진필요한 경우 선택적으로 첨부해주세요.
- 업적 페이지 내 변경 버튼에 `mutate`를 연결하지 않아 추가하였습니다.
- 업적 페이지 내 데이터가 `progressCount`가 `requirementValue`보다 횟수가 많은 버그가 있어 '~회 남았습니다'와 버튼 생성 유무 조건을 잠시 변경하였습니다. (그러므로 현재 변경 버튼은 나타나지 않습니다. 업적 데이터가 달성하였어도 `completed`가 모두 `false` 이므로)

# 🚦 특이 사항

