### PR TITLE
[refactor] 업적 웹소켓 프로토콜 변경

### DIFF
--- a/app/_common/components/WebSocketProvider.tsx
+++ b/app/_common/components/WebSocketProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
+import { Client } from "@stomp/stompjs";
 
 import { useQueryUserData } from "@/app/my-page/_hooks/useQueryUserData";
 
@@ -28,106 +29,95 @@ export const WebSocketProvider = ({
   children: React.ReactNode;
 }) => {
   const { toast } = useToast();
-  const { data: userData } = useQueryUserData();
-  const [message, setMessage] = useState<WebSocketMessage | null>(null);
+  const { data: userData, isFetched } = useQueryUserData();
   const [open, setOpen] = useState(false);
   const [modalState, setModalState] = useState<ModalState | null>(null);
-  const webSocket = useRef<WebSocket | null>(null);
-  const webSocketUrl = process.env.NEXT_PUBLIC_ACHIEVEMENT_SOCKET_URL!;
-  let reconnectInterval: NodeJS.Timeout;
+  const client = useRef<Client | null>(null);
 
   const connect = () => {
-    webSocket.current = new WebSocket(webSocketUrl);
-    webSocket.current.onopen = () => {
-      webSocket.current?.send(JSON.stringify({ userId: userData?.id }));
-      clearInterval(reconnectInterval);
+    const currentUserAccessToken = localStorage.getItem("accessToken");
+    client.current = new Client({
+      brokerURL: process.env.NEXT_PUBLIC_ACHIEVEMENT_SOCKET_URL,
+      connectHeaders: {
+        Authorization: `Bearer ${currentUserAccessToken}`,
+      },
+      reconnectDelay: 5000,
+    });
+
+    client.current.onConnect = () => {
+      client.current?.subscribe(
+        `/topic/achievement/${userData?.id}`,
+        async data => {
+          const { achievementId, completed, progressCount }: WebSocketMessage =
+            JSON.parse(data.body);
+          const { title, imgUrl, requirementValue } =
+            await getAchievementDetail(achievementId);
+          const achievementTitle = title ?? "null";
+          const toastTitle = "업적 진행률 갱신!";
+          const percentage =
+            progressCount === 0
+              ? 0
+              : Number((progressCount / requirementValue).toFixed(2)) * 100;
+
+          if (completed) {
+            setOpen(true);
+            setModalState({ title, imgUrl, requirementValue, progressCount });
+            return;
+          }
+
+          toast({
+            className: cn("bottom-4 right-0 fixed max-w-[350px] mr-3 z-[100]"),
+            title: toastTitle,
+            description: (
+              <main className="flex w-full flex-col gap-3 space-y-1 text-xs">
+                <aside className="flex items-center gap-3">
+                  <Avatar className="h-12 w-12 shadow-neo-thin">
+                    <AvatarImage src={imgUrl} />
+                    <AvatarFallback>CN</AvatarFallback>
+                  </Avatar>
+                  <h3 className="text-base font-bold">
+                    <span>{achievementTitle}</span>
+                    <span> 획득까지 앞으로 </span>
+                    <span className="text-neoRed">{progressCount}회!</span>
+                  </h3>
+                </aside>
+                <Progress
+                  value={completed ? 100 : percentage}
+                  background="blue"
+                  className="w-full grow"
+                />
+              </main>
+            ),
+            variant: "achievement",
+          });
+        },
+      );
     };
 
-    webSocket.current.onclose = error => {
-      reconnectInterval = setInterval(() => reconnect(), 5000);
-      console.log(error);
+    client.current.onWebSocketError = e => {
+      console.error(e);
     };
 
-    webSocket.current.onerror = error => {
-      console.log(error);
+    client.current.onWebSocketClose = e => {
+      console.error(e);
     };
 
-    webSocket.current.onmessage = (event: MessageEvent) => {
-      const data = JSON.parse(event.data);
-      setMessage(data);
-    };
+    client.current.activate();
   };
 
   const disconnect = () => {
-    clearInterval(reconnectInterval);
-    webSocket.current?.close();
-  };
-
-  const reconnect = () => {
-    if (webSocket.current?.readyState !== WebSocket.CONNECTING && userData) {
-      webSocket.current = new WebSocket(webSocketUrl);
-      connect();
-    }
+    client.current?.deactivate();
   };
 
   useEffect(() => {
-    if (userData) {
+    if (isFetched) {
       connect();
     }
 
     return () => {
       disconnect();
     };
-  }, [userData]);
-
-  useEffect(() => {
-    async function getAchievementTitle(message: WebSocketMessage) {
-      const { achievementId, completed, progressCount } = message;
-      const { title, imgUrl, requirementValue } =
-        await getAchievementDetail(achievementId);
-
-      const achievementTitle = title ?? "null";
-      const toastTitle = "업적 진행률 갱신!";
-      const percentage =
-        progressCount === 0
-          ? 0
-          : Number((progressCount / requirementValue).toFixed(2)) * 100;
-
-      if (completed) {
-        setOpen(true);
-        setModalState({ title, imgUrl, requirementValue, progressCount });
-        return;
-      }
-
-      toast({
-        className: cn("bottom-4 right-0 fixed max-w-[350px] mr-3 z-[100]"),
-        title: toastTitle,
-        description: (
-          <main className="flex w-full flex-col gap-3 space-y-1 text-xs">
-            <aside className="flex items-center gap-3">
-              <Avatar className="h-12 w-12 shadow-neo-thin">
-                <AvatarImage src={imgUrl} />
-                <AvatarFallback>CN</AvatarFallback>
-              </Avatar>
-              <h3 className="text-base font-bold">
-                <span>{achievementTitle}</span>
-                <span> 획득까지 앞으로 </span>
-                <span className="text-neoRed">{progressCount}회!</span>
-              </h3>
-            </aside>
-            <Progress
-              value={completed ? 100 : percentage}
-              background="blue"
-              className="w-full grow"
-            />
-          </main>
-        ),
-        variant: "achievement",
-      });
-    }
-
-    if (message) getAchievementTitle(message);
-  }, [message]);
+  }, [isFetched]);
 
   return (
     <WebSocketContext.Provider value={null}>

--- a/app/_common/components/WebSocketProvider.tsx
+++ b/app/_common/components/WebSocketProvider.tsx
@@ -78,7 +78,9 @@ export const WebSocketProvider = ({
                   <h3 className="text-base font-bold">
                     <span>{achievementTitle}</span>
                     <span> 획득까지 앞으로 </span>
-                    <span className="text-neoRed">{progressCount}회!</span>
+                    <span className="text-neoRed">
+                      {requirementValue - progressCount}회!
+                    </span>
                   </h3>
                 </aside>
                 <Progress

--- a/app/project/_hooks/useGetRequestListQuery.ts
+++ b/app/project/_hooks/useGetRequestListQuery.ts
@@ -34,6 +34,7 @@ function useGetRequestListQuery(
     queryKey: ["requestList", cursorId] as const,
     queryFn: getRequestList,
     enabled: user !== null && user.id === creatorId,
+    refetchInterval: 5000,
   });
 
   if (isLoading || !data) return { data: null };


### PR DESCRIPTION
# 📌 작업 내용
- [x] 기존 ws 프로토콜에서 stomp 프로토콜로 변경
- [x] 그에따른 연결 & 구독 로직 변경 

|업적 획득|업적 진행률|
|--|--|
|![스크린샷 2024-03-22 16 14 07](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/101445377/93b5bb2d-742a-4018-94dd-6852036edb79)|![스크린샷 2024-03-22 17 24 55](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/101445377/7fa07b45-ed5f-4199-88e7-18746fe0d34f)|

# 🚦 특이 사항
#### env 변경(로컬, 배포)
`NEXT_PUBLIC_ACHIEVEMENT_SOCKET_URL="wss://mogak-go.shop/ws/achievement"`

close #316 