### PR TITLE
[hotfix] input 클릭 시 축소가 안풀리는 버그 수정

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -47,7 +47,7 @@ export default function RootLayout({
         content="width=device-width, initial-scale=1, maximum-scale=1.0, 
     user-scalable=0"
       />
-      <body className="touch-pan-x touch-pan-y">
+      <body>
         <ClientProvider>
           <WebSocketProvider>
             <ThemeProvider

--- a/app/project/_components/FormPlace.tsx
+++ b/app/project/_components/FormPlace.tsx
@@ -38,7 +38,7 @@ function FormPlace(props: FormTagProps) {
                 placeholder="장소를 입력하세요."
                 value={placeInput || ""}
                 onChangeCapture={handleChangePlace}
-                className="shadow-neo-thin text-xs"
+                className="shadow-neo-thin text-lg"
                 autoComplete="off"
               />
               <PlaceList

--- a/app/project/_components/FormPlace.tsx
+++ b/app/project/_components/FormPlace.tsx
@@ -38,7 +38,7 @@ function FormPlace(props: FormTagProps) {
                 placeholder="장소를 입력하세요."
                 value={placeInput || ""}
                 onChangeCapture={handleChangePlace}
-                className="shadow-neo-thin"
+                className="shadow-neo-thin text-xs"
                 autoComplete="off"
               />
               <PlaceList

--- a/app/project/_components/FormTag.tsx
+++ b/app/project/_components/FormTag.tsx
@@ -35,7 +35,7 @@ function FormTag(props: FormTagProps) {
               <Input
                 ref={ref}
                 placeholder="e.g. 조용한, 수다스러운 (최대 3개)"
-                className="w-full shadow-neo-thin"
+                className="w-full shadow-neo-thin text-xs"
                 onKeyDown={handleAddTag}
               />
               <aside className="flex flex-wrap gap-1">

--- a/app/project/_components/FormTag.tsx
+++ b/app/project/_components/FormTag.tsx
@@ -28,14 +28,14 @@ function FormTag(props: FormTagProps) {
         <FormItem>
           <FormLabel className="text-base">
             <span>태그</span>
-            <span className="text-xs text-[#a2a2a2]"> 최대 7글자</span>
+            <span className="text-xs text-[#a2a2a2]"> 최대 7글자, 입력 후 Enter를 눌러주세요.</span>
           </FormLabel>
           <FormControl>
             <div className="flex flex-col gap-2">
               <Input
                 ref={ref}
                 placeholder="e.g. 조용한, 수다스러운 (최대 3개)"
-                className="w-full shadow-neo-thin text-xs"
+                className="w-full shadow-neo-thin text-lg"
                 onKeyDown={handleAddTag}
               />
               <aside className="flex flex-wrap gap-1">

--- a/app/project/layout.tsx
+++ b/app/project/layout.tsx
@@ -1,0 +1,14 @@
+import LoginRequestModal from "../my-page/_components/LoginRequestModal";
+
+export default function MyPageLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <LoginRequestModal />
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
# 📌 작업 내용
- [x] [fix] input 클릭 시 축소가 안풀리는 버그 수정

# 🚦 특이 사항
```html
<meta
        name="viewport"
        content="width=device-width, initial-scale=1, maximum-scale=1.0, 
    user-scalable=0"
      />
```

위의 코드를 추가하면, input을 클릭해도 확대가 안된다고 하는데 왜 확대가 될까요?