### PR TITLE
[refactor] navigate 함수 useRouter 훅으로 대체

### DIFF
--- a/app/_common/components/NavigationBottom.tsx
+++ b/app/_common/components/NavigationBottom.tsx
@@ -1,29 +1,30 @@
 "use client";
 
 import { MouseEvent } from "react";
+import { useRouter } from "next/navigation";
 import { usePathname } from "next/navigation";
 
 import { toast } from "../utils/toast";
-import { navigate } from "../utils/redirect";
 import { useAuthStore } from "../store/useAuthStore";
 import { cn } from "../shadcn/utils";
 import { Menubar, MenubarMenu, MenubarTrigger } from "../shadcn/ui/menubar";
 import WithOnMounted from "../hoc/WithOnMounted";
 
 function NavigationBottom() {
+  const router = useRouter();
   const pathname = usePathname();
   const { getUser } = useAuthStore();
 
   const handleNavigateClick = (event: MouseEvent<HTMLButtonElement>) => {
     const path = (event.target as HTMLButtonElement).value;
-    navigate(path);
+    router.push(path);
   };
 
   const handleNoAuthClick = () => {
     toast.info("로그인 후 이용해주세요!", {
       action: {
         label: "로그인하기",
-        onClick: () => navigate("login"),
+        onClick: () => router.push("/login"),
       },
     });
   };

--- a/app/login/_components/StartWithGithubButton.tsx
+++ b/app/login/_components/StartWithGithubButton.tsx
@@ -15,15 +15,15 @@ function StartWithGithubButton() {
   const githubUrl = new URL(envGithubUrl);
 
   return (
-    <Button className="w-full px-10 py-5" variant={"outline"} type="button">
-      <Link
-        className="flex w-full items-center justify-center gap-x-2"
-        href={githubUrl}
-      >
+    <Link
+      className="flex w-full items-center justify-center gap-x-2"
+      href={githubUrl}
+    >
+      <Button className="w-full px-10 py-5" variant={"outline"} type="button">
         <IconBrandGithub />
         깃허브로 시작하기
-      </Link>
-    </Button>
+      </Button>
+    </Link>
   );
 }
 

--- a/app/my-page/_components/LoginRequestModal.tsx
+++ b/app/my-page/_components/LoginRequestModal.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+
 import {
   AlertDialog,
   AlertDialogAction,
@@ -11,15 +13,14 @@ import {
   AlertDialogOverlay,
 } from "@/app/_common/shadcn/ui/alert-dialog";
 
-import { navigate } from "@/app/_common/utils/redirect";
-
 import { useQueryUserData } from "../_hooks/useQueryUserData";
 
 function LoginRequestModal() {
+  const router = useRouter();
   const { data, isLoading } = useQueryUserData();
 
   const handleClickLoginButton = () => {
-    navigate("/login");
+    router.push("/login");
   };
 
   return (

--- a/app/my-page/_components/LogoutButton.tsx
+++ b/app/my-page/_components/LogoutButton.tsx
@@ -1,3 +1,5 @@
+import { useRouter } from "next/navigation";
+
 import { Button } from "@/app/_common/shadcn/ui/button";
 import {
   AlertDialog,
@@ -12,15 +14,16 @@ import {
 } from "@/app/_common/shadcn/ui/alert-dialog";
 import WithOnMounted from "@/app/_common/hoc/WithOnMounted";
 
-import { navigate } from "@/app/_common/utils/redirect";
 import { deleteCookie } from "@/app/_common/utils/cookie";
 
 function LogoutButton() {
+  const router = useRouter();
+
   const handleClickLogout = async () => {
     try {
       await deleteCookie("refreshToken", { path: "/" });
       await localStorage.removeItem("accessToken");
-      navigate("/");
+      router.push("/");
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
# 📌 작업 내용
- 구현 내용 및 작업 했던 내역, 사진필요한 경우 선택적으로 첨부해주세요.
- [x] navigate 함수 useRouter 훅으로 대체
- [x] 로그인 버튼의 Link와 Button 태그 위치를 서로 변경하였습니다. 

# 🚦 특이 사항
- 버튼의 반응성이 크게 향상 되었습니다. 🎉
