### PR TITLE
[fix] pinch zoom, textarea 확대 비활성화

### DIFF
--- a/app/_common/shadcn/ui/textarea.tsx
+++ b/app/_common/shadcn/ui/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-black bg-white px-3 py-2 text-sm shadow-neo ring-offset-white transition-all placeholder:text-slate-500 focus-visible:translate-x-[3px] focus-visible:translate-y-[3px] focus-visible:shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
+          "flex min-h-[80px] w-full rounded-md border border-black bg-white px-3 py-2 text-lg shadow-neo ring-offset-white transition-all placeholder:text-slate-500 focus-visible:translate-x-[3px] focus-visible:translate-y-[3px] focus-visible:shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
           className,
         )}
         ref={ref}

--- a/app/globals.css
+++ b/app/globals.css
@@ -43,4 +43,5 @@ html,
 body {
   width: 100%;
   height: 100%;
+  touch-action: pan-y;
 }


### PR DESCRIPTION
# 📌 작업 내용

- textarea 포커스 시 확대되어 폰트 크기 확대로 화면 확대 비활성화
- 수직 스크롤만 가능하게끔 설정

# 🚦 특이 사항
- 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점을 작성해주세요.
