### PR TITLE
[fix] StackNavigator 레이아웃 처리 방식 flex로 변경

### DIFF
--- a/app/_common/components/StackNavigator.tsx
+++ b/app/_common/components/StackNavigator.tsx
@@ -9,13 +9,14 @@ import Icon from "./Icon";
 interface StackNavigatorProps extends ComponentProps<"header"> {
   element: React.ReactNode;
   path?: string;
+  rightItem?: React.ReactNode;
 }
 
 function StackNavigator({
   element,
   path,
+  rightItem,
   className,
-  children,
   ...props
 }: StackNavigatorProps) {
   const router = useRouter();
@@ -32,17 +33,21 @@ function StackNavigator({
 
   return (
     <header
-      className={cn("relative px-4 py-8 text-center text-lg", className)}
+      className={cn(
+        "relative flex w-full items-center justify-between px-4 py-8 text-center text-lg",
+        className,
+      )}
       {...props}
     >
-      <Icon
-        id="chevron-left"
-        size={24}
-        className="absolute cursor-pointer"
-        onClick={!path ? handleBack : handlePushPath}
-      />
+      <div className="cursor-pointer">
+        <Icon
+          id="chevron-left"
+          size={24}
+          onClick={!path ? handleBack : handlePushPath}
+        />
+      </div>
       <h2>{element}</h2>
-      {children}
+      <div className="cursor-pointer">{rightItem}</div>
     </header>
   );
 }

--- a/app/_common/components/StackNavigator.tsx
+++ b/app/_common/components/StackNavigator.tsx
@@ -12,6 +12,8 @@ interface StackNavigatorProps extends ComponentProps<"header"> {
   rightItem?: React.ReactNode;
 }
 
+const itemStyle = "flex-1 basis-1 *:cursor-pointer";
+
 function StackNavigator({
   element,
   path,
@@ -39,7 +41,7 @@ function StackNavigator({
       )}
       {...props}
     >
-      <div className="cursor-pointer">
+      <div className={itemStyle}>
         <Icon
           id="chevron-left"
           size={24}
@@ -47,7 +49,7 @@ function StackNavigator({
         />
       </div>
       <h2>{element}</h2>
-      <div className="cursor-pointer">{rightItem}</div>
+      <div className={itemStyle}>{rightItem}</div>
     </header>
   );
 }

--- a/app/my-page/page.tsx
+++ b/app/my-page/page.tsx
@@ -23,14 +23,17 @@ function MyPage() {
 
   return (
     <div className="relative">
-      <StackNavigator element={"마이페이지"}>
-        <Link
-          href={"/notification"}
-          className="absolute right-5 top-9 z-10 -translate-y-[0.1rem]"
-        >
-          <Icon id="notification" size={24} />
-        </Link>
-      </StackNavigator>
+      <StackNavigator
+        element={"마이페이지"}
+        rightItem={
+          <Link
+            href={"/notification"}
+            className="absolute right-5 top-9 z-10 -translate-y-[0.1rem]"
+          >
+            <Icon id="notification" size={24} />
+          </Link>
+        }
+      />
       <main className="container flex min-h-screen max-w-2xl flex-col gap-8 pb-24">
         <Profile />
         <Badges />


### PR DESCRIPTION
# 📌 작업 내용
- [x] StackNavigator 레이아웃 처리 방식 flex로 변경
- [x] 헤더 오른쪽 아이템을 지정할 수 있도록 커스텀

# 🚦 특이 사항
- StackNavigator 컴포넌트의 레이아웃 처리 방식을 flex로 변경하였습니다.
- 헤더 오른쪽 아이템을 props로 지정할 수 있도록 커스텀하였습니다.
![image](https://github.com/Open-Eye-Im-Developer/MoGakGo-FE/assets/86952779/05ce977b-91a1-4fdb-9d97-645ff4786c54)
