### PR TITLE
[fix] 업적 데이터에 progressLevel 추가로 인한 수정

### DIFF
--- a/app/_common/types/user.ts
+++ b/app/_common/types/user.ts
@@ -67,6 +67,7 @@ export interface Achievement {
   requirementValue: number;
   requirementType?: "SEQUENCE" | "ACCUMULATE";
   progressCount: number;
+  progressLevel: number;
   completed?: boolean;
 }
 

--- a/app/achievements/_components/AchievementItem.tsx
+++ b/app/achievements/_components/AchievementItem.tsx
@@ -47,6 +47,7 @@ function AchievementItem({
     description,
     requirementValue,
     progressCount,
+    progressLevel,
   } = achievement;
 
   const { mutate } = useMutationUserAchievement(setMyAchievement);
@@ -134,16 +135,17 @@ function AchievementItem({
                 </p>
               )}
 
-              {isCompleted &&
-                myAchievement?.achievementId !== achievementId && (
-                  <Button
-                    className="row-span-3"
-                    variant={"outline"}
-                    onClick={handleSubmitAchievement}
-                  >
-                    변경
-                  </Button>
-                )}
+              {progressLevel >= 2 ||
+                (isCompleted &&
+                  myAchievement?.achievementId !== achievementId && (
+                    <Button
+                      className="row-span-3"
+                      variant={"outline"}
+                      onClick={handleSubmitAchievement}
+                    >
+                      변경
+                    </Button>
+                  ))}
             </div>
           </AccordionContent>
         </AccordionItem>


### PR DESCRIPTION
# 📌 작업 내용
- [x] `progressLevel`이 2 이상이면 버튼이 나타나도록 수정하였습니다.
- [x] `Achievement` 타입에 `progressLevel`을 추가했습니다.

# 🚦 특이 사항
- 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점을 작성해주세요.
